### PR TITLE
fixed numbering of doppler static IPs

### DIFF
--- a/base/0-deployment-order.yml
+++ b/base/0-deployment-order.yml
@@ -74,7 +74,7 @@ instance_groups:
   stemcell: default
   networks:
   - name: (( grab params.cf_internal_network ))
-    static_ips: (( static_ips(15, 16, 17, 18, 19) ))
+    static_ips: (( static_ips(5, 6, 7, 8, 9) ))
 
 - name: loggregator_trafficcontroller
   instances: (( grab params.loggregator_instances ))


### PR DESCRIPTION
Fixing the doppler instance group static IPs so it uses the next available IPs in the cf_internal_network. 