### PR TITLE
Add support for new internal HA Postgres DB

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -230,11 +230,13 @@ can rely on cloud provider RDBMS offerings when appropriate.
 
 ### Using a Local Database
 
-The `local-db` feature adds a single, non-HA PostgreSQL node to
-the Cloud Foundry deployment.  This is a mostly hands-off change
-to the deployment, since the kit will generate all internal
-passwords, and automatically wire up to the new node for database
-DSNs.
+There are two feature options that are available, `local-db`, a
+single, non-HA PostgreSQL node, and `local-ha-db`, a dual-node
+master/replica HA PostgreSQL that uses a VRRP VIP with HAProxy.
+
+Both features are a mostly hands-off change to the deployment, since
+the kit will generate all internal passwords, and automatically wire
+up to the new node for database DSNs.
 
 This feature brings the [cloudfoundry-community/postgres][1] BOSH
 release into play.
@@ -250,6 +252,15 @@ The following parameters are defined:
   - `postgres_disk_pool` - The disk type (per cloud config) to use
     when provisioning the persistent storage for the database.
     Defaults to `postgres`.
+
+  - `postgres_max_connections` - How many connections the internal
+    Postgres DB should maintain at once. Only used if internal
+    DB is deployed. Defaults to `100`.
+
+  - `postgres_vip` - What VRRP VIP to use for the HAProxy/keepalived.
+
+If the `local-ha-db` feature is chosen, a VRRP VIP must be manually
+provided either via the Wizard or as `postgres_vip`
 
 ### Using an External MySQL / MariaDB Database
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -243,6 +243,24 @@ release into play.
 
 [1]: https://github.com/cloudfoundry-community/postgres-boshrelease
 
+#### Local Postgres (non-HA) DB
+
+The following parameters are defined:
+
+  - `postgres_vm_type` - The VM type (per cloud config) to use
+    when deploying the standalone database node.
+    Defaults to `large`.
+
+  - `postgres_disk_pool` - The disk type (per cloud config) to use
+    when provisioning the persistent storage for the database.
+    Defaults to `postgres`.
+
+  - `postgres_max_connections` - How many connections the internal
+    Postgres DB should maintain at once. Only used if internal
+    DB is deployed. Defaults to `100`.
+
+#### Local Postgres (HA) DB
+
 The following parameters are defined:
 
   - `postgres_vm_type` - The VM type (per cloud config) to use
@@ -258,9 +276,7 @@ The following parameters are defined:
     DB is deployed. Defaults to `100`.
 
   - `postgres_vip` - What VRRP VIP to use for the HAProxy/keepalived.
-
-If the `local-ha-db` feature is chosen, a VRRP VIP must be manually
-provided either via the Wizard or as `postgres_vip`
+    This field has no default, and must be provided.
 
 ### Using an External MySQL / MariaDB Database
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -4,7 +4,7 @@ set -eu
 declare -a merge
 
 validate_features nfs-volume-services small-footprint \
-                  local-db mysql-db postgres-db \
+                  local-db local-ha-db mysql-db postgres-db \
                   db-internal-postgres db-ha-internal-postgres db-external-mysql db-external-postgres \
                   aws-blobstore azure-blobstore gcp-blobstore local-blobstore \
                   blobstore-aws blobstore-azure blobstore-gcp blobstore-webdav \
@@ -96,7 +96,7 @@ database=0
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
   # Database selector feature flags
-  mysql-db|postgres-db|local-db)
+  mysql-db|postgres-db|local-db|local-ha-db)
     database=$(( database + 1 ))
     merge+=( manifests/db/${want%-db}.yml )
     ;;
@@ -110,7 +110,7 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
   db-ha-internal-postgres)
     database=$(( database + 1 ))
     echo >&2 "The db-ha-internal-postgres flag has been renamed to 'local-ha-db'"
-    merge+=( manifests/db/halocal.yml )
+    merge+=( manifests/db/local-ha.yml )
     ;;
 
   db-external-*)
@@ -122,7 +122,7 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
 done
 # If we haven't chosen a database, use local
 if [[ $database == 0 ]]; then
-  merge+=( manifests/db/local.yml )
+  merge+=( manifests/db/local-db.yml )
 fi
 
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -5,7 +5,7 @@ declare -a merge
 
 validate_features nfs-volume-services small-footprint \
                   local-db local-ha-db mysql-db postgres-db \
-                  db-internal-postgres db-ha-internal-postgres db-external-mysql db-external-postgres \
+                  db-internal-postgres db-external-mysql db-external-postgres \
                   aws-blobstore azure-blobstore gcp-blobstore local-blobstore \
                   blobstore-aws blobstore-azure blobstore-gcp blobstore-webdav \
                   haproxy tls self-signed \
@@ -96,21 +96,28 @@ database=0
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
   # Database selector feature flags
-  mysql-db|postgres-db|local-db|local-ha-db)
+  mysql-db|postgres-db)
     database=$(( database + 1 ))
     merge+=( manifests/db/${want%-db}.yml )
+    ;;
+
+  local-db|local-ha-db)
+    database=$(( database + 1 ))
+    merge+=( manifests/db/local.yml )
+    case "$want" in
+      local-db)
+        merge+=( manifests/db/local-single.yml )
+        ;;
+      local-ha-db)
+        merge+=( manifests/db/local-ha.yml )
+        ;;
+    esac
     ;;
 
   db-internal-postgres)
     database=$(( database + 1 ))
     echo >&2 "The db-internal-postgres flag has been renamed to 'local-db'"
     merge+=( manifests/db/local.yml )
-    ;;
-
-  db-ha-internal-postgres)
-    database=$(( database + 1 ))
-    echo >&2 "The db-ha-internal-postgres flag has been renamed to 'local-ha-db'"
-    merge+=( manifests/db/local-ha.yml )
     ;;
 
   db-external-*)
@@ -122,7 +129,7 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
 done
 # If we haven't chosen a database, use local
 if [[ $database == 0 ]]; then
-  merge+=( manifests/db/local-db.yml )
+  merge+=( manifests/db/local.yml )
 fi
 
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -101,17 +101,16 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     merge+=( manifests/db/${want%-db}.yml )
     ;;
 
-  local-db|local-ha-db)
+  local-db)
     database=$(( database + 1 ))
     merge+=( manifests/db/local.yml )
-    case "$want" in
-      local-db)
-        merge+=( manifests/db/local-single.yml )
-        ;;
-      local-ha-db)
-        merge+=( manifests/db/local-ha.yml )
-        ;;
-    esac
+    merge+=( manifests/db/local-single.yml )
+    ;;
+
+  local-ha-db)
+    database=$(( database + 1 ))
+    merge+=( manifests/db/local.yml )
+    merge+=( manifests/db/local-ha.yml )
     ;;
 
   db-internal-postgres)

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -5,7 +5,7 @@ declare -a merge
 
 validate_features nfs-volume-services small-footprint \
                   local-db mysql-db postgres-db \
-                  db-internal-postgres db-external-mysql db-external-postgres \
+                  db-internal-postgres db-ha-internal-postgres db-external-mysql db-external-postgres \
                   aws-blobstore azure-blobstore gcp-blobstore local-blobstore \
                   blobstore-aws blobstore-azure blobstore-gcp blobstore-webdav \
                   haproxy tls self-signed \
@@ -105,6 +105,12 @@ for want in ${GENESIS_REQUESTED_FEATURES}; do
     database=$(( database + 1 ))
     echo >&2 "The db-internal-postgres flag has been renamed to 'local-db'"
     merge+=( manifests/db/local.yml )
+    ;;
+
+  db-ha-internal-postgres)
+    database=$(( database + 1 ))
+    echo >&2 "The db-ha-internal-postgres flag has been renamed to 'local-ha-db'"
+    merge+=( manifests/db/halocal.yml )
     ;;
 
   db-external-*)

--- a/hooks/new
+++ b/hooks/new
@@ -68,7 +68,7 @@ ask_for_database() {
       -o '[postgres-db]  PostgreSQL Google Cloud SQL' \
       -o '[mysql-db]     MySQL Google Cloud SQL' \
       -o '[local-db]     an internal database node (not HA)' \
-      -o '[local-ha-db]     internal HA database cluster'
+      -o '[local-ha-db]  internal HA database cluster'
 
     case $database in
     postgres-db) inst="Google Cloud SQL PostgreSQL instance" ;;

--- a/hooks/new
+++ b/hooks/new
@@ -52,7 +52,8 @@ ask_for_database() {
       'Where would you like to house Cloud Foundry configuration and metadata?' \
       -o '[postgres-db]  PostgreSQL Amazon RDS' \
       -o '[mysql-db]     MySQL Amazon RDS' \
-      -o '[local-db]     an internal database node (not HA)'
+      -o '[local-db]     an internal database node (not HA)' \
+      -o '[local-ha-db]     internal HA database cluster'
 
     case $database in
     postgres-db) inst="Amazon RDS PostgreSQL instance" ;;
@@ -66,7 +67,8 @@ ask_for_database() {
       'Where would you like to house Cloud Foundry configuration and metadata?' \
       -o '[postgres-db]  PostgreSQL Google Cloud SQL' \
       -o '[mysql-db]     MySQL Google Cloud SQL' \
-      -o '[local-db]     an internal database node (not HA)'
+      -o '[local-db]     an internal database node (not HA)' \
+      -o '[local-ha-db]     internal HA database cluster'
 
     case $database in
     postgres-db) inst="Google Cloud SQL PostgreSQL instance" ;;
@@ -80,7 +82,8 @@ ask_for_database() {
       'Where would you like to house Cloud Foundry configuration and metadata?' \
       -o '[postgres-db]  External PostgreSQL Database' \
       -o '[mysql-db]     External MySQL Database' \
-      -o '[local-db]     an internal database node (not HA)'
+      -o '[local-db]     an internal database node (not HA)' \
+      -o '[local-ha-db]     internal HA database cluster'
 
     case $database in
     postgres-db) inst="external PostgreSQL instance" ;;

--- a/hooks/new
+++ b/hooks/new
@@ -83,7 +83,7 @@ ask_for_database() {
       -o '[postgres-db]  External PostgreSQL Database' \
       -o '[mysql-db]     External MySQL Database' \
       -o '[local-db]     an internal database node (not HA)' \
-      -o '[local-ha-db]     internal HA database cluster'
+      -o '[local-ha-db]  internal HA database cluster'
 
     case $database in
     postgres-db) inst="external PostgreSQL instance" ;;
@@ -98,6 +98,7 @@ ask_for_database() {
     ;;
   esac
 
+
   case $database in
   mysql-db|postgres-db)
     prompt_for db_host line \
@@ -107,6 +108,10 @@ ask_for_database() {
     prompt_for $GENESIS_VAULT_PREFIX/external_db:password secret-line \
       "What is the password for the $inst $db_user user?"
     safe --quiet set secret/$GENESIS_VAULT_PREFIX/external_db username="$db_user"
+    ;;
+  local-ha-db)
+    prompt_for postgres_vip line \
+      "What VIP would you like to use?"
     ;;
   esac
 }
@@ -249,6 +254,11 @@ postgres-db)
   echo "  # External PostgreSQL configuration"
   echo "  external_db_host: $db_host"
   ;;
+
+local-ha-db)
+  echo
+  echo "  # VIP for the HA Postgres DB"
+  echo "  postgres_vip: $postgres_vip"
 esac
 ) >$GENESIS_ROOT/$GENESIS_ENVIRONMENT.yml
 

--- a/hooks/new
+++ b/hooks/new
@@ -53,7 +53,7 @@ ask_for_database() {
       -o '[postgres-db]  PostgreSQL Amazon RDS' \
       -o '[mysql-db]     MySQL Amazon RDS' \
       -o '[local-db]     an internal database node (not HA)' \
-      -o '[local-ha-db]     internal HA database cluster'
+      -o '[local-ha-db]  internal HA database cluster'
 
     case $database in
     postgres-db) inst="Amazon RDS PostgreSQL instance" ;;

--- a/kit.yml
+++ b/kit.yml
@@ -185,3 +185,13 @@ credentials:
       password: random 64
     shield:
       password: random 64
+
+  local-ha-db:
+    uaadb:
+      password: random 64
+    ccdb:
+      password: random 64
+    diegodb:
+      password: random 64
+    shield:
+      password: random 64

--- a/manifests/db/halocal.yml
+++ b/manifests/db/halocal.yml
@@ -1,0 +1,89 @@
+---
+params:
+  uaadb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  uaadb_user:     uaaadmin
+  uaadb_password: (( vault meta.vault "/uaadb:password" ))
+  uaadb_scheme:   postgresql
+  uaadb_port:     5432
+
+  ccdb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  ccdb_user:     ccadmin
+  ccdb_password: (( vault meta.vault "/ccdb:password" ))
+  ccdb_scheme:   postgres
+  ccdb_port:     5432
+
+  diegodb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  diegodb_user:     diegoadmin
+  diegodb_password: (( vault meta.vault "/diegodb:password" ))
+  diegodb_scheme:   postgres
+  diegodb_port:     5432
+  diegodb_connection_string: (( concat params.diegodb_scheme "://" params.diegodb_user ":" params.diegodb_password "@" params.diegodb_host ":" params.diegodb_port "/" params.diegodb_name ))
+
+  postgres_disk_pool: postgres
+  postgres_vm_type:   large
+
+releases:
+  - name: postgres
+    version: 1.0.4
+    sha1: 8b82c86b7763abdb8f117523b852d1e1c9a20eeb
+    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v1.0.4/postgres-1.0.4.tgz
+
+instance_groups:
+  - (( insert after "nats" ))
+  - name: postgres
+    instances: 1
+    persistent_disk_pool: (( grab params.postgres_disk_pool ))
+    vm_type: (( grab params.postgres_vm_type ))
+    azs: (( grab params.availability_zones || meta.default.azs ))
+    stemcell: default
+    networks:
+      - name: (( grab params.cf_db_network ))
+        static_ips: (( static_ips 0 ))
+
+    jobs:
+      - name: consul_agent
+        release: consul
+        consumes:
+          consul_common: {from: consul_common_link}
+          consul_server: nil
+          consul_client: {from: consul_client_link}
+      - name: postgres
+        release: postgres
+        properties:
+          pgpool:
+            databases:
+              - name:        (( grab params.ccdb_name ))
+                users:      [(( grab params.ccdb_user ))]
+                extensions: [citext, pgcrypto]
+
+              - name:        (( grab params.uaadb_name ))
+                users:      [(( grab params.uaadb_user ))]
+                extensions: [citext, pgcrypto]
+
+              - name:        (( grab params.diegodb_name ))
+                users:      [(( grab params.diegodb_user ))]
+                extensions: [citext, pgcrypto]
+
+            users:
+            - username: (( grab params.uaadb_user ))
+              password: (( grab params.uaadb_password ))
+
+            - username: (( grab params.ccdb_user ))
+              password: (( grab params.ccdb_password ))
+
+            - username: (( grab params.diegodb_user ))
+              password: (( grab params.diegodb_password ))
+
+            - username: shield
+              password: (( vault meta.vault "/shield:password" ))
+              admin: true
+
+          postgres:
+            config:
+              port: 5432
+              listen_addresses: '*'
+            hba:
+            - host all all 0.0.0.0/0 md5
+            - host all all ::/0 md5
+            replication:
+              enabled: false

--- a/manifests/db/local-ha.yml
+++ b/manifests/db/local-ha.yml
@@ -1,93 +1,24 @@
 ---
 params:
-  uaadb_host:     (( grab params.postgres_vip ))
-  uaadb_user:     uaaadmin
-  uaadb_password: (( vault meta.vault "/uaadb:password" ))
-  uaadb_scheme:   postgresql
-  uaadb_port:     5432
-
+  uaadb_host:    (( grab params.postgres_vip ))
   ccdb_host:     (( grab params.postgres_vip ))
-  ccdb_user:     ccadmin
-  ccdb_password: (( vault meta.vault "/ccdb:password" ))
-  ccdb_scheme:   postgres
-  ccdb_port:     5432
-
-  diegodb_host:     (( grab params.postgres_vip ))
-  diegodb_user:     diegoadmin
-  diegodb_password: (( vault meta.vault "/diegodb:password" ))
-  diegodb_scheme:   postgres
-  diegodb_port:     5432
-  diegodb_connection_string: (( concat params.diegodb_scheme "://" params.diegodb_user ":" params.diegodb_password "@" params.diegodb_host ":" params.diegodb_port "/" params.diegodb_name ))
-
-  postgres_disk_pool: postgres
-  postgres_vm_type:   large
-
-releases:
-  - name: postgres
-    version: 3.0.0
-    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.0.0/postgres-3.0.0.tgz
-    sha1: a5070c285d44b3ac0fb678b1ae640461668b87c5
-
-
+  diegodb_host:  (( grab params.postgres_vip ))
 
 instance_groups:
-  - (( insert after "nats" ))
   - name: postgres
     instances: 2
-    persistent_disk_pool: (( grab params.postgres_disk_pool ))
-    vm_type: (( grab params.postgres_vm_type ))
-    azs: (( grab params.availability_zones || meta.default.azs ))
-    stemcell: default
     networks:
       - name: (( grab params.cf_db_network ))
     jobs:
-      - name: consul_agent
-        release: consul
-        consumes:
-          consul_common: {from: consul_common_link}
-          consul_server: nil
-          consul_client: {from: consul_client_link}
       - name: vip
+        release: postgres
         properties:
           vip: (( grab params.postgres_vip ))
           readonly_port: 7432
-        release: postgres
       - name: postgres
-        release: postgres
         properties:
           postgres:
-            users:
-            - username: (( grab params.uaadb_user ))
-              password: (( grab params.uaadb_password ))
-
-            - username: (( grab params.ccdb_user ))
-              password: (( grab params.ccdb_password ))
-
-            - username: (( grab params.diegodb_user ))
-              password: (( grab params.diegodb_password ))
-
-            - username: shield
-              password: (( vault meta.vault "/shield:password" ))
-              admin: true
-            databases:
-              - name:        (( grab params.ccdb_name ))
-                users:      [(( grab params.ccdb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.uaadb_name ))
-                users:      [(( grab params.uaadb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.diegodb_name ))
-                users:      [(( grab params.diegodb_user ))]
-                extensions: [citext, pgcrypto]
-                
             config:
               port: 6432
-              listen_addresses: '*'
-              max_connections: (( grab params.postgres_max_connections || 100 ))
-            hba:
-            - host all all 0.0.0.0/0 md5
-            - host all all ::/0 md5
             replication:
               enabled: true

--- a/manifests/db/local-ha.yml
+++ b/manifests/db/local-ha.yml
@@ -1,18 +1,18 @@
 ---
 params:
-  uaadb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  uaadb_host:     (( grab params.postgres_vip ))
   uaadb_user:     uaaadmin
   uaadb_password: (( vault meta.vault "/uaadb:password" ))
   uaadb_scheme:   postgresql
   uaadb_port:     5432
 
-  ccdb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  ccdb_host:     (( grab params.postgres_vip ))
   ccdb_user:     ccadmin
   ccdb_password: (( vault meta.vault "/ccdb:password" ))
   ccdb_scheme:   postgres
   ccdb_port:     5432
 
-  diegodb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  diegodb_host:     (( grab params.postgres_vip ))
   diegodb_user:     diegoadmin
   diegodb_password: (( vault meta.vault "/diegodb:password" ))
   diegodb_scheme:   postgres
@@ -24,22 +24,22 @@ params:
 
 releases:
   - name: postgres
-    version: 1.0.4
-    sha1: 8b82c86b7763abdb8f117523b852d1e1c9a20eeb
-    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v1.0.4/postgres-1.0.4.tgz
+    version: 3.0.0
+    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.0.0/postgres-3.0.0.tgz
+    sha1: a5070c285d44b3ac0fb678b1ae640461668b87c5
+
+
 
 instance_groups:
   - (( insert after "nats" ))
   - name: postgres
-    instances: 1
+    instances: 2
     persistent_disk_pool: (( grab params.postgres_disk_pool ))
     vm_type: (( grab params.postgres_vm_type ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
     networks:
       - name: (( grab params.cf_db_network ))
-        static_ips: (( static_ips 0 ))
-
     jobs:
       - name: consul_agent
         release: consul
@@ -47,23 +47,15 @@ instance_groups:
           consul_common: {from: consul_common_link}
           consul_server: nil
           consul_client: {from: consul_client_link}
+      - name: vip
+        properties:
+          vip: (( grab params.postgres_vip ))
+          readonly_port: 7432
+        release: postgres
       - name: postgres
         release: postgres
         properties:
-          pgpool:
-            databases:
-              - name:        (( grab params.ccdb_name ))
-                users:      [(( grab params.ccdb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.uaadb_name ))
-                users:      [(( grab params.uaadb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.diegodb_name ))
-                users:      [(( grab params.diegodb_user ))]
-                extensions: [citext, pgcrypto]
-
+          postgres:
             users:
             - username: (( grab params.uaadb_user ))
               password: (( grab params.uaadb_password ))
@@ -77,13 +69,25 @@ instance_groups:
             - username: shield
               password: (( vault meta.vault "/shield:password" ))
               admin: true
+            databases:
+              - name:        (( grab params.ccdb_name ))
+                users:      [(( grab params.ccdb_user ))]
+                extensions: [citext, pgcrypto]
 
-          postgres:
+              - name:        (( grab params.uaadb_name ))
+                users:      [(( grab params.uaadb_user ))]
+                extensions: [citext, pgcrypto]
+
+              - name:        (( grab params.diegodb_name ))
+                users:      [(( grab params.diegodb_user ))]
+                extensions: [citext, pgcrypto]
+                
             config:
-              port: 5432
+              port: 6432
               listen_addresses: '*'
+              max_connections: (( grab params.postgres_max_connections || 100 ))
             hba:
             - host all all 0.0.0.0/0 md5
             - host all all ::/0 md5
             replication:
-              enabled: false
+              enabled: true

--- a/manifests/db/local-single.yml
+++ b/manifests/db/local-single.yml
@@ -1,0 +1,5 @@
+instance_groups:
+  - name: postgres
+    networks:
+      - name: (( grab params.cf_db_network ))
+        static_ips: (( static_ips 0 ))

--- a/manifests/db/local.yml
+++ b/manifests/db/local.yml
@@ -36,10 +36,6 @@ instance_groups:
     vm_type: (( grab params.postgres_vm_type ))
     azs: (( grab params.availability_zones || meta.default.azs ))
     stemcell: default
-    networks:
-      - name: (( grab params.cf_db_network ))
-        static_ips: (( static_ips 0 ))
-
     jobs:
       - name: consul_agent
         release: consul
@@ -52,18 +48,18 @@ instance_groups:
         properties:
           postgres:
             users:
-            - username: (( grab params.uaadb_user ))
-              password: (( grab params.uaadb_password ))
+              - username: (( grab params.uaadb_user ))
+                password: (( grab params.uaadb_password ))
 
-            - username: (( grab params.ccdb_user ))
-              password: (( grab params.ccdb_password ))
+              - username: (( grab params.ccdb_user ))
+                password: (( grab params.ccdb_password ))
 
-            - username: (( grab params.diegodb_user ))
-              password: (( grab params.diegodb_password ))
+              - username: (( grab params.diegodb_user ))
+                password: (( grab params.diegodb_password ))
 
-            - username: shield
-              password: (( vault meta.vault "/shield:password" ))
-              admin: true
+              - username: shield
+                password: (( vault meta.vault "/shield:password" ))
+                admin: true
             databases:
               - name:        (( grab params.ccdb_name ))
                 users:      [(( grab params.ccdb_user ))]

--- a/manifests/db/local.yml
+++ b/manifests/db/local.yml
@@ -24,9 +24,9 @@ params:
 
 releases:
   - name: postgres
-    version: 1.0.4
-    sha1: 8b82c86b7763abdb8f117523b852d1e1c9a20eeb
-    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v1.0.4/postgres-1.0.4.tgz
+    version: 3.0.0
+    url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.0.0/postgres-3.0.0.tgz
+    sha1: a5070c285d44b3ac0fb678b1ae640461668b87c5
 
 instance_groups:
   - (( insert after "nats" ))
@@ -50,20 +50,7 @@ instance_groups:
       - name: postgres
         release: postgres
         properties:
-          pgpool:
-            databases:
-              - name:        (( grab params.ccdb_name ))
-                users:      [(( grab params.ccdb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.uaadb_name ))
-                users:      [(( grab params.uaadb_user ))]
-                extensions: [citext, pgcrypto]
-
-              - name:        (( grab params.diegodb_name ))
-                users:      [(( grab params.diegodb_user ))]
-                extensions: [citext, pgcrypto]
-
+          postgres:
             users:
             - username: (( grab params.uaadb_user ))
               password: (( grab params.uaadb_password ))
@@ -77,11 +64,23 @@ instance_groups:
             - username: shield
               password: (( vault meta.vault "/shield:password" ))
               admin: true
+            databases:
+              - name:        (( grab params.ccdb_name ))
+                users:      [(( grab params.ccdb_user ))]
+                extensions: [citext, pgcrypto]
 
-          postgres:
+              - name:        (( grab params.uaadb_name ))
+                users:      [(( grab params.uaadb_user ))]
+                extensions: [citext, pgcrypto]
+
+              - name:        (( grab params.diegodb_name ))
+                users:      [(( grab params.diegodb_user ))]
+                extensions: [citext, pgcrypto]
+                
             config:
               port: 5432
               listen_addresses: '*'
+              max_connections: (( grab params.postgres_max_connections || 100 ))
             hba:
             - host all all 0.0.0.0/0 md5
             - host all all ::/0 md5


### PR DESCRIPTION
As of https://github.com/cloudfoundry-community/postgres-boshrelease/commit/7d1dd2fa6445839f3e6b8d61d1246b862dc563b8 our Postgres bosh release used for internal DB now supports a two-node cluster HA. This PR adds the option to use an internal HA Postgres as a backend.