### PR TITLE
Fix Missed Instance Counts for small-footprint

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -145,7 +145,7 @@ fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
-  azure|nfs-volume-services|small-footprint)
+  azure|nfs-volume-services)
     merge+=( manifests/addons/$want.yml )
     ;;
 
@@ -193,7 +193,13 @@ fi
 
 
 
-# AUTOSCALER
+   ###    ##     ## ########  #######   ######   ######     ###    ##       ######## ########
+  ## ##   ##     ##    ##    ##     ## ##    ## ##    ##   ## ##   ##       ##       ##     ##
+ ##   ##  ##     ##    ##    ##     ## ##       ##        ##   ##  ##       ##       ##     ##
+##     ## ##     ##    ##    ##     ##  ######  ##       ##     ## ##       ######   ########
+######### ##     ##    ##    ##     ##       ## ##       ######### ##       ##       ##   ##
+##     ## ##     ##    ##    ##     ## ##    ## ##    ## ##     ## ##       ##       ##    ##
+##     ##  #######     ##     #######   ######   ######  ##     ## ######## ######## ##     ##
 
 if want_feature autoscaler; then
   merge+=( manifests/addons/app-autoscaler.yml )
@@ -202,6 +208,21 @@ if want_feature autoscaler; then
              manifests/db/local-single.yml )
   fi
 fi
+
+
+
+########  #######   #######  ######## ########  ########  #### ##    ## ########
+##       ##     ## ##     ##    ##    ##     ## ##     ##  ##  ###   ##    ##
+##       ##     ## ##     ##    ##    ##     ## ##     ##  ##  ####  ##    ##
+######   ##     ## ##     ##    ##    ########  ########   ##  ## ## ##    ##
+##       ##     ## ##     ##    ##    ##        ##   ##    ##  ##  ####    ##
+##       ##     ## ##     ##    ##    ##        ##    ##   ##  ##   ###    ##
+##        #######   #######     ##    ##        ##     ## #### ##    ##    ##
+
+if want_feature small-footprint; then
+  merge+=( manifests/addons/small-footprint.yml )
+fi
+
    ######     ###    ##    ## #### ######## ##    ##
   ##    ##   ## ##   ###   ##  ##     ##     ##  ##
   ##        ##   ##  ####  ##  ##     ##      ####

--- a/manifests/addons/small-footprint.yml
+++ b/manifests/addons/small-footprint.yml
@@ -11,9 +11,18 @@ params:
   uaa_instances:         1
   api_instances:         1
   doppler_instances:     1
+  syslogger_instances:   1
   loggregator_instances: 1
   router_instances:      1
   bbs_instances:         1
   diego_instances:       1
   access_instances:      1
   cell_instances:        1
+
+  autoscaler_api_instances:       1
+  autoscaler_scheduler_instances: 1
+  autoscaler_broker_instances:    1
+  autoscaler_pruner_instances:    1
+  autoscaler_collector_instances: 1
+  autoscaler_scaler_instances:    1
+  autoscaler_engine_instances:    1


### PR DESCRIPTION
Due to merge order, and some missing params.x overrides, small-footprint
was larger than it could have been.

Fixes #34