### PR TITLE
Fix locketdb and silkdb writing to 'postgres' database

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+# Bug Fixes
+
+Previously, we had an incorrect spruce operation that confused `scheme` and
+`schema`, which resulted in locketdb and silkdb data being written to a
+database named `postgres` (rather than `locketdb` and `silkdb`, respectively.)
+
+If you are upgrading from CF Genesis Kit version 1.1.0, 1.1.1, or 1.1.2, a
+Genesis Migration Path (GMP) must be performed. Please visit
+[CF-M0001: Database Scheme Fix Migration)[https://genesisproject.io/docs/migrations/cf/cf-m0001/] 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,9 +1,9 @@
 # Bug Fixes
 
 Previously, we had an incorrect spruce operation that confused `scheme` and
-`schema`, which resulted in locketdb and silkdb data being written to a
-database named `postgres` (rather than `locketdb` and `silkdb`, respectively.)
+`schema`, which resulted in locketdb and diegodb data being written to a
+database named `postgres` (rather than `locketdb` and `diegodb`, respectively.)
 
 If you are upgrading from CF Genesis Kit version 1.1.0, 1.1.1, or 1.1.2, a
 Genesis Migration Path (GMP) must be performed. Please visit
-[CF-M0001: Database Scheme Fix Migration)[https://genesisproject.io/docs/migrations/cf/cf-m0001/] 
+[GMP-CF-0001: Database Scheme Fix Migration)[http://www.genesisproject.io/docs/migrations/gmp-cf-0001/] 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -5,5 +5,7 @@ Previously, we had an incorrect spruce operation that confused `scheme` and
 database named `postgres` (rather than `locketdb` and `diegodb`, respectively.)
 
 If you are upgrading from CF Genesis Kit version 1.1.0, 1.1.1, or 1.1.2, a
-Genesis Migration Path (GMP) must be performed. Please visit
-[GMP-CF-0001: Database Scheme Fix Migration)[http://www.genesisproject.io/docs/migrations/gmp-cf-0001/] 
+Genesis Migration Process (GMP) must be performed. Please review
+[GMP-CF-0001: Database Scheme Fix Migration][gmp-cf-0001]
+
+[gmp-cf-0001]: http://www.genesisproject.io/docs/migrations/gmp-cf-0001

--- a/manifests/cf/bbs.yml
+++ b/manifests/cf/bbs.yml
@@ -44,7 +44,7 @@ instance_groups:
               db_driver: (( grab params.diegodb_scheme ))
               max_open_connections: 500
               db_port: (( grab params.diegodb_port ))
-              db_schema: (( grab params.diegodb_scheme ))
+              db_schema: (( grab params.diegodb_name ))
               db_host: (( grab params.diegodb_host ))
               db_password: (( grab params.diegodb_password ))
               db_username: (( grab params.diegodb_user ))
@@ -82,7 +82,7 @@ instance_groups:
             sql:
               db_host: (( grab params.locketdb_host ))
               db_port:  (( grab params.locketdb_port ))
-              db_schema:  (( grab params.locketdb_scheme ))
+              db_schema:  (( grab params.locketdb_name ))
               db_username:  (( grab params.locketdb_user ))
               db_password:  (( grab params.locketdb_password ))
               db_driver:  (( grab params.locketdb_scheme ))


### PR DESCRIPTION
We had an incorrect spruce operation that confused `scheme` and
`schema`, which resulted in locketdb and silkdb data being written to a
database named `postgres` (rather than `locketdb` and `silkdb`,
respectively.)

This commit fixes this. However, it is not a backwards compatible
commit. If there is a current CF running that was deployed from CF
Genesis Kit versions 1.1.0 to 1.1.2, data migration is necessary.

See release notes for v1.2 for more information.