### PR TITLE
Update loggregator.yml

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,11 @@
 # Bug Fixes
 
+- Added syslog_drain to Loggregator services. Syslog draining should now work
+  as expected
+- Fixed Locket and Diego using wrong database name regardless of configuration
+
+# Important, Please Read
+
 Previously, we had an incorrect spruce operation that confused `scheme` and
 `schema`, which resulted in locketdb and diegodb data being written to a
 database named `postgres` (rather than `locketdb` and `diegodb`, respectively.)

--- a/manifests/cf/loggregator.yml
+++ b/manifests/cf/loggregator.yml
@@ -51,7 +51,7 @@ instance_groups:
         agent:
           services:
             loggregator_trafficcontroller: {}
-              reverse_log_proxy: {}
+            reverse_log_proxy: {}
   - name: loggregator_trafficcontroller
     release: loggregator
     consumes:

--- a/manifests/cf/loggregator.yml
+++ b/manifests/cf/loggregator.yml
@@ -51,7 +51,7 @@ instance_groups:
         agent:
           services:
             loggregator_trafficcontroller: {}
-
+              reverse_log_proxy: {}
   - name: loggregator_trafficcontroller
     release: loggregator
     consumes:

--- a/manifests/cf/releases.yml
+++ b/manifests/cf/releases.yml
@@ -88,9 +88,9 @@ releases:
   version: 1.3.0
   sha1: 5b9357484032e5217cead8f20362f5802c751de0
 - name: cf-syslog-drain
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=6.5
-  version: "6.5"
-  sha1: 2764d9ad86e71b354dc127238895c0db8352d5eb
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=7.1
+  version: "7.1"
+  sha1: 7e9648f44c6513ea5cb84531c9c5d1ae0730f202
 - name: uaa
   url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=59
   version: "59"


### PR DESCRIPTION
Missing reverse log proxy for loggregator causing following errors on syslog adapters: 

`Failed to connect to loggregator API: lookup reverse-log-proxy.service.cf.internal on 127.0.0.1:53: no such host`