### PR TITLE
Fix migration off consul issues (autoscalar, default blobstore and db)

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -10,3 +10,7 @@
   ```
   
   This fix swaps them, placing them in the correct hierarchy.
+
+- Again with the `migrate-1.3-without-consul` feature, if using default
+  blobstore or database, the consul components were not being removed.  This
+  is now fixed.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,12 @@
+# Bug Fixes
+
+- When features `autoscaler` and `migrate-1.3-without-consul` are both
+  enabled, the removal code tries to update the `eventgenerator` and
+  `metricscollector` properties in the `jobs` section in the wrong
+  `instance_groups`, which results in the following error message:
+
+  ```
+  Error: Cannot tell what release template 'eventgenerator' (instance group 'as-collector')uuuis supposed to use, please explicitly specify one
+  ```
+  
+  This fix swaps them, placing them in the correct hierarchy.

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -262,6 +262,12 @@ if want_feature migrate-1.3-without-consul; then
 
     esac
   done
+  if [[ $database == 0 ]]; then
+    merge+=( manifests/migrations/remove-consul-postgres.yml )
+  fi
+  if [[ $blobstore == 0 ]]; then
+    merge+=( manifests/migrations/remove-consul-blobstore.yml )
+  fi
 fi
 
    ######     ###    ##    ## #### ######## ##    ##

--- a/manifests/migrations/remove-consul-autoscaler.yml
+++ b/manifests/migrations/remove-consul-autoscaler.yml
@@ -37,7 +37,7 @@ instance_groups:
     jobs:
       - (( delete "consul_agent" ))
       - (( merge ))
-      - name: eventgenerator
+      - name: metricscollector
         properties:
           autoscaler:
             require_consul: false
@@ -46,7 +46,7 @@ instance_groups:
     jobs:
       - (( delete "consul_agent" ))
       - (( merge ))
-      - name: metricscollector
+      - name: eventgenerator
         properties:
           autoscaler:
             require_consul: false


### PR DESCRIPTION
When features `autoscaler` and `migrate-1.3-without-consul` are both enabled, the removal code tries to update the `eventgenerator` and `metricscollector` properties in the `jobs` section in the wrong `instance_groups`, which results in the following error message:

```
Error: Cannot tell what release template 'eventgenerator' (instance group 'as-collector')uuuis supposed to use, please explicitly specify one
```

This fix swaps them, placing them in the correct hierarchy.

Also, if using default blobstore or database, the consul components were not being removed.  This is now fixed.