### PR TITLE
Release 1.6.0

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -85,6 +85,10 @@ runtime config.
     delete unneeded layers as need to keep this space free. `-1`
     disables GC. Defaults to `15360`.
 
+  - `vm_strategy` - The method used for managing vm rotation.  By default, it
+    is `delete-create`, but it can also be set to `create-swap-delete` to
+    minimize downtime.
+
     [2]: (#branding)
 
 ## Deployment Parameters

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -412,6 +412,11 @@ Certificates will then be automatically generated with the proper
 subject alternate names for all of the domains (system and apps)
 that Cloud Foundry will use.
 
+## Container Routing Integrity
+
+The `container-routing-integrity` feature enables TLS Validation of the cells.
+See [HTTP Routing#With TLS Enabled](https://docs.cloudfoundry.org/concepts/http-routing.html#with-tls)
+
 ## Small Footprint Cloud Foundry
 
 Sometimes, you may want to sacrifice redundancy and high

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -519,6 +519,17 @@ Documentation](https://git.io/fNt3l)
 This kit allows for using the v3 api's [Zero Downtime (ZDT) deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) via the
 capi release's cc_deployment_updater.
 
+# DNS
+
+This release makes use of the BOSH DNS, and uses DNS addresses instead of IP
+addresses.  If IP addresses are needed instead, you can turn off this feature
+for for this deployment by setting `features.use_dns_addresses` to `false`.
+You may also have to turn off `director.local_dns.use_dns_addresses` as well.
+
+See [Native DNS Support](https://bosh.io/docs/dns) for more information about
+DNS, and [here](https://bosh.io/docs/dns/#links) for specific information
+about using DNS entries in links.
+
 # Branding
 An operator may need to set the branding options available through a
 typical UAA deployment. Genesis exposes these configuration options

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -514,6 +514,11 @@ the service to each app manually. More information about App
 Autoscaler can be found on [App Autoscaler's Policy
 Documentation](https://git.io/fNt3l)
 
+# Zero-downtime App Deployments
+
+This kit allows for using the v3 api's [Zero Downtime (ZDT) deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) via the
+capi release's cc_deployment_updater.
+
 # Branding
 An operator may need to set the branding options available through a
 typical UAA deployment. Genesis exposes these configuration options

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -648,6 +648,8 @@ vm_extensions:
 
 # History
 
+Version 1.6.0 is based on changes up to v9.5.0 of the cf-deployment release
+
 Version 1.5.0 completely removes usage of consul, instead relying on BOSH DNS.
 
 Version 1.0.0 was the first version to support Genesis 2.6 hooks

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,107 @@
+# Major Update
+
+This release brings the releases used by the CF Genesis Kit up to date with
+[v9.5.0 of the cf-deployment release][cfd-9.5.0].  This release is
+upgradable from the previous releases (assuming you go through the removal
+of `consul` as per releases v1.3.x - v1.5.x of this kit).
+
+[cfd-9.5.0]: https://github.com/cloudfoundry/cf-deployment/releases/tag/v9.5.0
+
+# Improvements
+
+- Space Developers are now able to set up network policies without platform
+  operator involvement.
+
+- Containerd is now the default containerization runtime for Diego, instead
+  of garden/runc.  If you want the old behavior, you can specify the
+  `native-garden-runc` feature.
+
+- You can now set the VM update strategy via the `vm_strategy` param.
+
+- gorouter and access VMs now provide shared BOSH links.
+
+- App Autoscaler has been fixed and upgraded to 2.0.0, thanks to
+  [anishp55][pr54].
+
+- NFS Volume Services has been upgraded to v2.3.0 (see below for details).
+
+- Consul has been officially removed (see below for details).
+
+- Significant improvements to move communications to TLS
+
+- Additional loggregator metrics
+
+[pr54]: https://github.com/genesis-community/cf-genesis-kit/pull/54
+
+
+## NFS Volume Services
+
+NFS Volume Services, which can be enabled via the `nfs-volume-services` feature,
+has been upgraded to v2.3.0.  This should be paired with the [updated
+nfs-broker genesis kit][nfsbroker-0.2.0]
+
+[nfsbroker-0.2.0]: https://github.com/genesis-community/nfs-broker-genesis-kit/releases/tag/v0.2.0
+
+## Regarding Consul Deprecation
+
+Consul is no longer supported, and was removed in release v1.5.0.  While
+replacing consul with BOSH DNS was optional since v1.3.0 using the feature
+`migrate-1.3-without-consul`, that feature is no longer necessary..
+
+You should be able to directly upgrade to this version with no impact to your
+existing Cloud Foundry system.  We recommend that you validate by upgrading
+to v1.4.1 with `migrate-1.3.1-without-consul` enabled so that if something
+does break, you can redeploy without that feature.
+
+You must [enable BOSH DNS](https://bosh.io/docs/dns/#enable) in your BOSH
+deployment via runtime config
+[(example)](https://github.com/cloudfoundry/bosh-deployment/blob/master/runtime-configs/dns.yml)
+to deploy this version.
+
+
+# Core Components
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| app-autoscaler | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019 |
+| bosh-dns-aliases | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3) | 24 October 2018 |
+| bpm | [1.1.0](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.0) | 28 May 2019 |
+| capi | [1.83.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.83.0) | 28 June 2019 |
+| cf-cli | [1.16.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.16.0) | 04 June 2019 |
+| cf-networking | [2.23.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.23.0) | 17 June 2019 |
+| cf-smoke-tests | [40.0.112](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/v40.0.112) | - |
+| cf-syslog-drain | [10.2](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2) | 13 May 2019 |
+| cflinuxfs2 | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0) | 12 June 2019 |
+| cflinuxfs3 | [0.113.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.113.0) | 08 July 2019 |
+| diego | [2.34.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.34.0) | 02 July 2019 |
+| garden-runc | [1.19.3](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.3) | 25 June 2019 |
+| haproxy | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1) | 05 September 2019 |
+| log-cache | [2.2.2](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.2.2) | 31 May 2019 |
+| loggregator | [105.5](https://github.com/cloudfoundry/loggregator-release/releases/tag/v105.5) | 06 May 2019 |
+| loggregator-agent | [3.9](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v3.9) | 15 March 2019 |
+| mapfs | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0) | 15 July 2019 |
+| nats | [27](https://github.com/cloudfoundry/nats-release/releases/tag/v27) | 16 May 2019 |
+| nfs-volume | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0) | 21 August 2019 |
+| postgres | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0) | 19 September 2019 |
+| routing | [0.188.0](https://github.com/cloudfoundry-incubator/cf-routing-release/releases/tag/0.188.0) | 12 April 2019 |
+| silk | [2.23.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.23.0) | 17 June 2019 |
+| statsd-injector | [1.10.0](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.10.0) | 16 April 2019 |
+| uaa | [72.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v72.0) | 14 May 2019 |
+
+
+# Buildpacks
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| binary | [1.0.32](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.32) | 01 May 2019 |
+| dotnet-core | [2.2.12](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.2.12) | 14 June 2019 |
+| go | [1.8.39](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.8.39) | 01 May 2019 |
+| java | [4.19](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.19) | 26 April 2019 |
+| nginx | [1.0.13](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.0.13) | 14 June 2019 |
+| nodejs | [1.6.51](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.6.51) | 14 June 2019 |
+| php | [4.3.77](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.3.77) | 14 June 2019 |
+| python | [1.6.34](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.6.34) | 14 June 2019 |
+| r | [1.0.10](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.0.10) | 14 June 2019 |
+| ruby | [1.7.40](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.7.40) | 14 June 2019 |
+| staticfile | [1.4.43](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.4.43) | 14 June 2019 |
+

--- a/ci/scripts/build-upstream-list
+++ b/ci/scripts/build-upstream-list
@@ -1,0 +1,27 @@
+#!/bin/bash
+dir=$(dirname $0)
+( 
+cd $dir/../.. &&
+out="$(eval "spruce merge --skip-eval $( \
+  grep -rl '^releases:' manifests/ \
+  | sed -e "s/\\(.*\\)/<(spruce json \\1 | jq -r '{releases: .releases}')/" |tr "\n" " " \
+  ) | spruce json | jq -r ." )"
+
+echo "$out" \
+  | jq -r 'reduce .releases[] as {$name, $url, $sha1, $version} ({core: [], buildpacks: []};
+    ($url 
+      | if ($url | test("https?://bosh.io")) then 
+          ($url | sub("^.*/d/";"https://") | sub("\\?v=.*$";"/releases/tag/${version}"))
+        elif ($url | test("https?://github.com")) then
+          ($url | sub("^.*http";"http") | sub("/download/.*$";"/tag/${version}"))
+        else
+          $url
+        end
+      ) as $notes |
+      if ($name | test("-buildpack$")) then 
+        (.buildpacks += [{name: ($name|sub("-buildpack";"")),$notes}])
+      else 
+        (.core += [{$name,$notes}])
+      end
+    )' | spruce merge --skip-eval > ci/upstream.yml
+)

--- a/ci/scripts/release-notes
+++ b/ci/scripts/release-notes
@@ -4,6 +4,7 @@ use strict;
 use YAML qw(LoadFile);
 use JSON::PP qw(decode_json);
 use File::Find;
+use Data::Dumper;
 
 my (%CORE, %BUILDPACKS);
 if (!$ENV{GITHUB_ACCESS_TOKEN}) {
@@ -14,14 +15,20 @@ if (!$ENV{GITHUB_ACCESS_TOKEN}) {
 my @months = qw(ignored January February March April May June July August September October November December);
 sub github {
 	my $url = shift;
-	my ($org, $repo, $tag) = ($url =~ m{github.com/(.*?)/(.*?)/releases/tag/(.*?)$});
+	my ($protocol,$org, $repo, $tag) = ($url =~ m{^(.*?)github.com/(.*?)/(.*?)/releases/tag/(.*?)$});
 
 	my $out = qx(curl -Ls -u "$ENV{GITHUB_ACCESS_TOKEN}:" https://api.github.com/repos/$org/$repo/releases/tags/$tag);
 	my $data = decode_json($out);
-	return "-" unless $data->{published_at};
+	if (defined($data->{message}) && $data->{message} eq "Not Found") {
+		$out = qx(curl -Ls -u "$ENV{GITHUB_ACCESS_TOKEN}:" https://api.github.com/repos/$org/$repo/releases/tags/v$tag);
+		$data = decode_json($out);
+		$url = "${protocol}github.com/$org/$repo/releases/tag/v$tag";
+	}
+
+	return ($url, "-") unless $data->{published_at};
 	my ($year, $mon, $day) = ($data->{published_at} =~ m/^(\d{4})-(\d{2})-(\d{2})/);
 
-	return "$day $months[$mon] $year";
+	return ($url,"$day $months[$mon] $year");
 }
 
 my %versions;
@@ -70,7 +77,8 @@ for my $c (@{$upstream->{core}}) {
 	$c->{label} ||= $c->{name};
 	if ($c->{notes}) {
 		(my $url = $c->{notes}) =~ s/\${version}/$versions{$c->{name}}/g;
-		my $dated = ($url =~ m/github.com/) ? github($url) : '-';
+		my $dated = '-';
+		($url, $dated) = github($url) if ($url =~ m/github.com/);
 		print "| $c->{label} | [$versions{$c->{name}}]($url) | $dated |\n";
 	} else {
 		print "| $c->{label} | $versions{$c->{name}} | - |\n";

--- a/ci/upstream.yml
+++ b/ci/upstream.yml
@@ -1,86 +1,73 @@
----
-# This file contains patterns for generating links to upstream release notes,
-# for constituent releases.
-
-core:
-  - name:  bosh-dns-aliases
-    label: bosh-dns-aliases (new)
-    notes: https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v${version}
-
-  - name:  bpm
-    notes: https://github.com/cloudfoundry-incubator/bpm-release/releases/tag/v${version}
-
-  - name:  capi
-    notes: https://github.com/cloudfoundry/capi-release/releases/tag/${version}
-
-  - name:  cf-smoke-tests
-
-  - name:  cf-networking
-    notes: https://github.com/cloudfoundry/cf-networking-release/releases/tag/v${version}
-
-  - name:  cflinuxfs2
-    notes: https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v${version}
-
-  - name:  cf-syslog-drain
-    notes: https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v${version}
-
-  - name:  diego
-    notes: https://github.com/cloudfoundry/diego-release/releases/tag/v${version}
-
-  - name:  garden-runc
-    notes: https://github.com/cloudfoundry/garden-runc-release/releases/tag/v${version}
-
-  - name:  loggregator
-    notes: https://github.com/cloudfoundry/loggregator-release/releases/tag/v${version}
-
-  - name:  loggregator-agent
-    label: loggregator-agent (renamed from metron_agent)
-    notes: https://github.com/cloudfoundry/log-cache-release/releases/tag/v${version}
-
-  - name:  log-cache
-    label: log-cache (new)
-    notes: https://github.com/cloudfoundry/log-cache-release/releases/tag/v${version}
-
-  - name:  nats
-    notes: https://github.com/cloudfoundry/nats-release/releases/tag/v${version}
-
-  - name:  routing
-    notes: https://github.com/cloudfoundry/routing-release/releases/tag/${version}
-
-  - name:  silk
-    label: silk (renamed from cf-networking)
-    notes: https://github.com/cloudfoundry/silk-release/releases/tag/${version}
-
-  - name:  statsd-injector
-    notes: https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v${version}
-
-  - name:  uaa
-    notes: https://github.com/cloudfoundry/uaa-release/releases/tag/v${version}
-
 buildpacks:
-  - name:  binary
-    notes: https://github.com/cloudfoundry/binary-buildpack/releases/tag/v${version}
+- name: binary
+  notes: https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/${version}
+- name: dotnet-core
+  notes: https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/${version}
+- name: go
+  notes: https://github.com/cloudfoundry/go-buildpack-release/releases/tag/${version}
+- name: java
+  notes: https://github.com/cloudfoundry/java-buildpack-release/releases/tag/${version}
+- name: nginx
+  notes: https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/${version}
+- name: nodejs
+  notes: https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/${version}
+- name: php
+  notes: https://github.com/cloudfoundry/php-buildpack-release/releases/tag/${version}
+- name: python
+  notes: https://github.com/cloudfoundry/python-buildpack-release/releases/tag/${version}
+- name: r
+  notes: https://github.com/cloudfoundry/r-buildpack-release/releases/tag/${version}
+- name: ruby
+  notes: https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/${version}
+- name: staticfile
+  notes: https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/${version}
+core:
+- name: bpm
+  notes: https://github.com/cloudfoundry/bpm-release/releases/tag/${version}
+- name: capi
+  notes: https://github.com/cloudfoundry/capi-release/releases/tag/${version}
+- name: cf-networking
+  notes: https://github.com/cloudfoundry/cf-networking-release/releases/tag/${version}
+- name: cf-smoke-tests
+  notes: https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/${version}
+- name: cflinuxfs2
+  notes: https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/${version}
+- name: cflinuxfs3
+  notes: https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/${version}
+- name: cf-cli
+  notes: https://github.com/bosh-packages/cf-cli-release/releases/tag/${version}
+- name: diego
+  notes: https://github.com/cloudfoundry/diego-release/releases/tag/${version}
+- name: garden-runc
+  notes: https://github.com/cloudfoundry/garden-runc-release/releases/tag/${version}
+- name: loggregator
+  notes: https://github.com/cloudfoundry/loggregator-release/releases/tag/${version}
+- name: loggregator-agent
+  notes: https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/${version}
+- name: log-cache
+  notes: https://github.com/cloudfoundry/log-cache-release/releases/tag/${version}
+- name: nats
+  notes: https://github.com/cloudfoundry/nats-release/releases/tag/${version}
+- name: routing
+  notes: https://github.com/cloudfoundry-incubator/cf-routing-release/releases/tag/${version}
+- name: statsd-injector
+  notes: https://github.com/cloudfoundry/statsd-injector-release/releases/tag/${version}
+- name: cf-syslog-drain
+  notes: https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/${version}
+- name: uaa
+  notes: https://github.com/cloudfoundry/uaa-release/releases/tag/${version}
+- name: silk
+  notes: https://github.com/cloudfoundry/silk-release/releases/tag/${version}
+- name: bosh-dns-aliases
+  notes: https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/${version}
+- name: app-autoscaler
+  notes: https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/${version}
+- name: nfs-volume
+  notes: https://github.com/cloudfoundry/nfs-volume-release/releases/tag/${version}
+- name: mapfs
+  notes: https://github.com/cloudfoundry/mapfs-release/releases/tag/${version}
+- name: postgres
+  notes: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/${version}
+- name: haproxy
+  notes: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/${version}
 
-  - name:  dotnet-core
-    notes: https://github.com/cloudfoundry/dotnet-core-buildpack/releases/tag/v${version}
-
-  - name:  go
-    notes: https://github.com/cloudfoundry/go-buildpack/releases/tag/v${version}
-
-  - name:  java
-    notes: https://github.com/cloudfoundry/java-buildpack/releases/tag/v${version}
-
-  - name: nodejs
-    notes: https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v${version}
-
-  - name:  php
-    notes: https://github.com/cloudfoundry/php-buildpack/releases/tag/v${version}
-
-  - name:  python
-    notes: https://github.com/cloudfoundry/python-buildpack/releases/tag/v${version}
-
-  - name:  ruby
-    notes: https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v${version}
-
-  - name:  staticfile
-    notes: https://github.com/cloudfoundry/staticfile-buildpack/releases/tag/v${version}

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -14,7 +14,8 @@ validate_features nfs-volume-services small-footprint \
                   autoscaler autoscaler-postgres \
                   haproxy-tls haproxy-notls omit-haproxy \
                   migrate-1.3-without-consul\
-                  container-routing-integrity
+                  container-routing-integrity\
+                  native-garden-runc
 
 merge=( manifests/cf/base.yml
         manifests/cf/releases.yml
@@ -150,7 +151,7 @@ fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
-  azure|nfs-volume-services|container-routing-integrity)
+  azure|nfs-volume-services|container-routing-integrity|native-garden-runc)
     merge+=( manifests/addons/$want.yml )
     ;;
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -152,7 +152,7 @@ fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
-  azure|nfs-volume-services|container-routing-integrity|native-garden-runc)
+  azure|nfs-volume-services|container-routing-integrity|native-garden-runc|loggregator-forwarder-agent)
     merge+=( manifests/addons/$want.yml )
     ;;
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -13,7 +13,8 @@ validate_features nfs-volume-services small-footprint \
                   minimum-vms \
                   autoscaler autoscaler-postgres \
                   haproxy-tls haproxy-notls omit-haproxy \
-                  migrate-1.3-without-consul
+                  migrate-1.3-without-consul\
+                  container-routing-integrity
 
 merge=( manifests/cf/base.yml
         manifests/cf/releases.yml
@@ -149,7 +150,7 @@ fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
-  azure|nfs-volume-services)
+  azure|nfs-volume-services|container-routing-integrity)
     merge+=( manifests/addons/$want.yml )
     ;;
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -17,6 +17,7 @@ validate_features nfs-volume-services small-footprint \
 
 merge=( manifests/cf/base.yml
         manifests/cf/releases.yml
+        manifests/cf/buildpacks.yml
         manifests/cf/certs.yml
 
         manifests/cf/access.yml

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -15,7 +15,8 @@ validate_features nfs-volume-services small-footprint \
                   haproxy-tls haproxy-notls omit-haproxy \
                   migrate-1.3-without-consul\
                   container-routing-integrity\
-                  native-garden-runc
+                  native-garden-runc\
+                  loggregator-forwarder-agent
 
 merge=( manifests/cf/base.yml
         manifests/cf/releases.yml

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -13,9 +13,9 @@ validate_features nfs-volume-services small-footprint \
                   minimum-vms \
                   autoscaler autoscaler-postgres \
                   haproxy-tls haproxy-notls omit-haproxy \
-                  migrate-1.3-without-consul\
-                  container-routing-integrity\
-                  native-garden-runc\
+                  migrate-1.3-without-consul \
+                  container-routing-integrity \
+                  native-garden-runc \
                   loggregator-forwarder-agent
 
 merge=( manifests/cf/base.yml

--- a/kit.yml
+++ b/kit.yml
@@ -111,7 +111,7 @@ certificates:
         names: [ "api.${params.base_domain}", "cloud-controller-ng.service.cf.internal" ]
       loggregator_rlp_gateway:
         valid_for: 1y
-        names: [ "rlp-gateway" ]
+        names: [ "rlp-gateway", "log-api.service.cf.internal" ]
     diego/certs/instance_identity:
       ca: { valid_for: 1y }
 
@@ -119,31 +119,31 @@ certificates:
       ca: { valid_for: 1y }
       doppler:
         valid_for: 1y
-        names: [ "doppler" ]
+        names: [ "doppler", "doppler.service.cf.internal" ]
       metron:
         valid_for: 1y
         names: [ "metron" ]
       trafficcontroller:
         valid_for: 1y
-        names: [ "trafficcontroller" ]
+        names: [ "trafficcontroller", "log-api.service.cf.internal" ]
       statsdinjector:
         valid_for: 1y
-        names: [ "statsdinjector"]
+        names: [ "statsdinjector", "uaa.service.cf.internal" ]
       syslogger_server:
         valid_for: 1y
-        names: [ "ss-adapter" ]
+        names: [ "ss-adapter", "adapter.service.cf.internal" ]
       syslogger_rlp:
         valid_for: 1y
-        names: [ "ss-adapter-rlp", "reverselogproxy" ]
+        names: [ "ss-adapter-rlp", "reverselogproxy", "adapter.service.cf.internal" ]
       syslogger_client:
         valid_for: 1y
-        names: [ "ss-scheduler" ]
+        names: [ "ss-scheduler", "scheduler.service.cf.internal" ]
       log_cache:
         valid_for: 1y
-        names: ["log-cache", "log_cache", "logcache"]
+        names: ["log-cache", "log_cache", "logcache", "doppler.service.cf.internal" ]
       rlp_gateway:
         valid_for: 1y
-        names: ["rlp_gateway"]
+        names: ["rlp_gateway", "log-api.service.cf.internal" ]
       expvar_forwarder:
         valid-for: 1y
         names: ["extvar_forwarder"]

--- a/kit.yml
+++ b/kit.yml
@@ -144,6 +144,9 @@ certificates:
       rlp_gateway:
         valid_for: 1y
         names: ["rlp_gateway"]
+      expvar_forwarder:
+        valid-for: 1y
+        names: ["extvar_forwarder"]
 
 
     dns_healthcheck_tls:

--- a/kit.yml
+++ b/kit.yml
@@ -70,6 +70,12 @@ certificates:
       cc_uploader_server:
         valid_for: 1y
         names: ["cc-uploader.service.cf.internal"]
+      cc_deployment_updater:
+        valid_for: 1y
+        names: [ "cc_deployment_updater" ]
+      cc_deployment_updater_server:
+        valid_for: 1y
+        names: ["cc-uploader.service.cf.internal"]
       syslogdrainbinder:
         valid_for: 1y
         names: [ "syslogdrainbinder" ]

--- a/kit.yml
+++ b/kit.yml
@@ -112,6 +112,9 @@ certificates:
       loggregator_rlp_gateway:
         valid_for: 1y
         names: [ "rlp-gateway", "log-api.service.cf.internal" ]
+      ssh_proxy_backends_tls:
+        valid_for: 1y
+        names: [ "ssh_proxy_backends_tls", "ssh-proxy.service.cf.internal" ]
     diego/certs/instance_identity:
       ca: { valid_for: 1y }
 

--- a/kit.yml
+++ b/kit.yml
@@ -112,9 +112,6 @@ certificates:
       loggregator_rlp_gateway:
         valid_for: 1y
         names: [ "rlp-gateway", "log-api.service.cf.internal" ]
-      forwarder_api_tls:
-        valid_for: 1y
-        names: [ "forwarder" ]
       ssh_proxy_backends_tls:
         valid_for: 1y
         names: [ "ssh_proxy_backends_tls", "ssh-proxy.service.cf.internal" ]

--- a/kit.yml
+++ b/kit.yml
@@ -112,9 +112,13 @@ certificates:
       loggregator_rlp_gateway:
         valid_for: 1y
         names: [ "rlp-gateway", "log-api.service.cf.internal" ]
+      forwarder_api_tls:
+        valid_for: 1y
+        names: [ "forwarder" ]
       ssh_proxy_backends_tls:
         valid_for: 1y
         names: [ "ssh_proxy_backends_tls", "ssh-proxy.service.cf.internal" ]
+
     diego/certs/instance_identity:
       ca: { valid_for: 1y }
 
@@ -150,6 +154,9 @@ certificates:
       expvar_forwarder:
         valid-for: 1y
         names: ["extvar_forwarder"]
+      forwarder_agent:
+        valid-for: 1y
+        names: [ "metron" ]
 
 
     dns_healthcheck_tls:

--- a/kit.yml
+++ b/kit.yml
@@ -269,6 +269,7 @@ credentials:
       tcp_emitter:    random 64
       tcp_router:     random 64
       network_policy: random 64
+      cf_smoke_tests: random 64
 
     cc:
       directory_key:     random 16 allowed-chars a-z0-9 fixed

--- a/manifests/addons/app-autoscaler.yml
+++ b/manifests/addons/app-autoscaler.yml
@@ -3,8 +3,6 @@ releases:
   version: "2.0.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=2.0.0"
   sha1: "b2bda4bd9ff9b902fa6a6f3d37c13b681b3402b0"
-- name: bpm
-  version: 1.1.1
 
 exodus:
   autoscaler_enabled: true

--- a/manifests/addons/app-autoscaler.yml
+++ b/manifests/addons/app-autoscaler.yml
@@ -1,22 +1,21 @@
 releases:
 - name: "app-autoscaler"
   version: "2.0.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=2.0.0"
+  url:  (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=" releases.app-autoscaler.version ))
   sha1: "b2bda4bd9ff9b902fa6a6f3d37c13b681b3402b0"
 
 exodus:
   autoscaler_enabled: true
   autoscaler_servicebroker_username: (( vault meta.vault "/autoscaler/servicebroker_account:username" ))
   autoscaler_servicebroker_password: (( vault meta.vault "/autoscaler/servicebroker_account:password" ))
-  autoscaler_servicebroker_url: (( grab params.autoscaler_broker_url || meta.broker_url ))
+  autoscaler_servicebroker_url: (( grab params.autoscaler_broker_url || meta.autoscaler.broker_url ))
 
 instance_groups:
-# APIServer Instance Group
 - name: as-api
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_api_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_api_vm_type || "default" ))
   jobs:
@@ -28,12 +27,9 @@ instance_groups:
           cache_ttl: 600
           http_client_timeout: 60000
           service_offering_enabled: true
-          db_config: &dbConfig
-            idle_timeout: 1000
-            max_connections: 10
-            min_connections: 0
+          db_config: (( grab meta.autoscaler.db_config ))
           port: 6100
-          publicPort: &apiServerPublicPort 6106
+          publicPort: (( grab meta.autoscaler.api_server_public_port ))
           health:
             port: 6200
           ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
@@ -58,32 +54,18 @@ instance_groups:
           eventgenerator:
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/eventgenerator_client:certificate" ))
-            client_key: (( vault meta.vault "/autoscaler/certs/eventgenerator_client:key" ))    
+            client_key: (( vault meta.vault "/autoscaler/certs/eventgenerator_client:key" ))
           service_broker:
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/servicebroker_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/servicebroker_client:key" ))
-        policy_db: &database
-          databases:
-          - name: autoscaler
-            tag: default
-          address: (( grab params.autoscalerdb_host || params.external_db_host ))
-          db_scheme: postgres
-          port: (( grab params.autoscalerdb_port || params.external_db_port ))
-          roles:
-          - name: (( grab params.autoscalerdb_user || params.external_db_username ))
-            password: (( grab params.autoscalerdb_password || params.external_db_password ))
-            tag: default 
-          connection_config: &databaseConnectionConfig
-            max_open_connections: 100
-            max_idle_connections: 10
-            connection_max_lifetime: 60s
+        policy_db: (( grab meta.autoscaler.db ))
         cf:
           api: (( concat "https://" meta.api_hostname ))
           skip_ssl_validation: (( grab params.skip_ssl_validation ))
           grant_type: client_credentials
           client_id: app_autoscaler
-          secret: (( vault meta.vault "/uaa/client_secrets:app_autoscaler" )) 
+          secret: (( vault meta.vault "/uaa/client_secrets:app_autoscaler" ))
   - name: route_registrar
     release: routing
     consumes:
@@ -93,18 +75,18 @@ instance_groups:
         routes:
         - name: api_server_public_api
           registration_interval: 20s
-          port: *apiServerPublicPort
+          port: (( grab meta.autoscaler.api_server_public_port ))
           tags:
             component: api_server
           uris:
             - (( concat "autoscaler." params.system_domain ))
-      
+
 # Scheduler Instance Group
 - name: as-scheduler
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_scheduler_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_scheduler_vm_type || "default" ))
   jobs:
@@ -113,9 +95,9 @@ instance_groups:
     properties:
       autoscaler:
         scheduler:
-          port: &schedulerPort 6102
+          port: (( grab meta.autoscaler.scheduler_port ))
           health:
-            port: &schedulerHealthPort 6202 
+            port: (( grab meta.autoscaler.scheduler_health_port ))
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
           notification_reschedule_maxcount: 3
@@ -127,14 +109,14 @@ instance_groups:
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/scalingengine_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/scalingengine_client:key" ))
-        scheduler_db: *database
-        policy_db: *database
+        scheduler_db: (( grab meta.autoscaler.db ))
+        policy_db: (( grab meta.autoscaler.db ))
 # Service-Broker Instance Group
 - name: as-broker
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_broker_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_broker_vm_type || "default" ))
   jobs:
@@ -143,8 +125,8 @@ instance_groups:
     properties:
       autoscaler:
         service_broker:
-          db_config: *dbConfig
-          publicPort: &servicebrokerPort 6101
+          db_config: (( grab meta.autoscaler.db_config ))
+          publicPort: (( grab meta.autoscaler.servicebroker_port ))
           port: 6107
           health:
             port: 6201
@@ -159,18 +141,18 @@ instance_groups:
           http_request_timeout: 5000
           require_consul: false
           dashboard_redirect_uri: ""
-          catalog: 
+          catalog:
             services:
             - id: autoscaler-guid
               name: autoscaler
               description: Automatically increase or decrease the number of application instances based on a policy you define.
               bindable: true
-              plans: (( grab params.autscaler_plans || meta.example_plan ))
+              plans: (( grab params.autscaler_plans || meta.autoscaler.example_plan ))
           api_server:
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/apiserver_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/apiserver_client:key" ))
-        binding_db: *database
+        binding_db: (( grab meta.autoscaler.db ))
   - name: route_registrar
     release: routing
     consumes:
@@ -180,18 +162,18 @@ instance_groups:
         routes:
         - name: autoscaler_service_broker
           registration_interval: 20s
-          port: *servicebrokerPort
+          port: (( grab meta.autoscaler.servicebroker_port ))
           tags:
             component: autoscaler_service_broker
           uris:
-            - (( grab meta.broker_url ))
+            - (( grab meta.autoscaler.broker_url ))
 
 # Metric-collector Instance Group
 - name: as-collector
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_collector_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_collector_vm_type || "default" ))
   jobs:
@@ -199,28 +181,21 @@ instance_groups:
     release: app-autoscaler
     properties:
       autoscaler:
-        instancemetrics_db: *database
-        policy_db: *database
-        lock_db: *database
-        instancemetrics_db_connection_config: *databaseConnectionConfig
-        policy_db_connection_config: *databaseConnectionConfig
-        lock_db_connection_config: *databaseConnectionConfig
+        instancemetrics_db: (( grab meta.autoscaler.db ))
+        policy_db: (( grab meta.autoscaler.db ))
+        lock_db: (( grab meta.autoscaler.db ))
+        instancemetrics_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        policy_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        lock_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
         require_consul: false
-        cf: &cfCredentials
-          api: (( concat "https://" meta.api_hostname ))
-          grant_type: password
-          username: admin
-          password: (( vault meta.vault "/admin_user:password" ))
-          client_id: app_autoscaler
-          secret: (( vault meta.vault "/uaa/client_secrets:app_autoscaler" ))
-          skip_ssl_validation: (( grab params.skip_ssl_validation ))
+        cf: (( grab meta.autoscaler.cf_credentials ))
         metricscollector:
           logging:
             level: debug
           server:
-            port: &metricsCollectorPort 6103
-          health: 
-            port: &metricsCollectorHealthPort 6203
+            port: (( grab meta.autoscaler.metrics_collector_port ))
+          health:
+            port: (( grab meta.autoscaler.metrics_collector_health_port ))
           collector:
             refresh_interval: 60s
             collect_interval: 30s
@@ -235,7 +210,7 @@ instance_groups:
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_scaler_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_scaler_vm_type || "default" ))
   jobs:
@@ -243,20 +218,20 @@ instance_groups:
     release: app-autoscaler
     properties:
       autoscaler:
-        appmetrics_db: *database
-        policy_db: *database
-        lock_db: *database
-        appmetrics_db_connection_config: *databaseConnectionConfig
-        policy_db_connection_config: *databaseConnectionConfig
-        lock_db_connection_config: *databaseConnectionConfig
+        appmetrics_db: (( grab meta.autoscaler.db ))
+        policy_db: (( grab meta.autoscaler.db ))
+        lock_db: (( grab meta.autoscaler.db ))
+        appmetrics_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        policy_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        lock_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
         require_consul: false
         eventgenerator:
           logging:
             level: debug
           server:
-            port: &eventGeneratorPort 6105
+            port: (( grab meta.autoscaler.event_generator_port ))
           health:
-            port: &eventGeneratorHealthPort 6205
+            port: (( grab meta.autoscaler.event_generator_health_port ))
           ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
           server_cert: (( vault meta.vault "/autoscaler/certs/eventgenerator_server:certificate" ))
           server_key: (( vault meta.vault "/autoscaler/certs/eventgenerator_server:key" ))
@@ -280,13 +255,13 @@ instance_groups:
           enable_db_lock: false
           scaling_engine:
             host: scalingengine.service.cf.internal
-            port: *scalingEnginePort
+            port: (( grab meta.autoscaler.scaling_engine_port ))
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/scalingengine_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/scalingengine_client:key" ))
           metricscollector:
             host: metricscollector.service.cf.internal
-            port: *metricsCollectorPort
+            port: (( grab meta.autoscaler.metrics_collector_port ))
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/metricscollector_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/metricscollector_client:key" ))
@@ -296,7 +271,7 @@ instance_groups:
   azs: (( grab params.availability_zones || meta.default.azs ))
   instances: (( grab params.autoscaler_engine_instances || 1 ))
   networks:
-  - name: (( grab params.autoscaler_network || "cf-autoscaler"  )) 
+  - name: (( grab params.autoscaler_network || "cf-autoscaler"  ))
   stemcell: default
   vm_type: (( grab params.autoscaler_engine_vm_type || "default" ))
   jobs:
@@ -304,23 +279,23 @@ instance_groups:
     release: app-autoscaler
     properties:
       autoscaler:
-        scalingengine_db: *database
-        scheduler_db: *database
-        policy_db: *database
-        lock_db: *database
-        scalingengine_db_connection_config: *databaseConnectionConfig
-        scheduler_db_connection_config: *databaseConnectionConfig
-        policy_db_connection_config: *databaseConnectionConfig
-        lock_db_connection_config: *databaseConnectionConfig
+        scalingengine_db: (( grab meta.autoscaler.db ))
+        scheduler_db: (( grab meta.autoscaler.db ))
+        policy_db: (( grab meta.autoscaler.db ))
+        lock_db: (( grab meta.autoscaler.db ))
+        scalingengine_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        scheduler_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        policy_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        lock_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
         require_consul: false
-        cf: *cfCredentials
+        cf: (( grab meta.autoscaler.cf_credentials ))
         scalingengine:
           logging:
             level: debug
           server:
-            port: &scalingEnginePort 6104
+            port: (( grab meta.autoscaler.scaling_engine_port ))
           health:
-            port: &scalingEngineHealthPort 6204
+            port: (( grab meta.autoscaler.scaling_engine_health_port ))
           defaultCoolDownSecs: 300
           lockSize: 32
           ca_cert:  (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
@@ -344,44 +319,88 @@ instance_groups:
     release: app-autoscaler
     properties:
       autoscaler:
-        cf: *cfCredentials
-        policy_db: *database
-        appmetrics_db: *database
-        instancemetrics_db: *database
-        scalingengine_db: *database
-        policy_db_connection_config: *databaseConnectionConfig
-        appmetrics_db_connection_config: *databaseConnectionConfig
-        instancemetrics_db_connection_config: *databaseConnectionConfig
-        scalingengine_db_connection_config: *databaseConnectionConfig
-        lock_db: *database
+        cf: (( grab meta.autoscaler.cf_credentials ))
+        policy_db: (( grab meta.autoscaler.db ))
+        appmetrics_db: (( grab meta.autoscaler.db ))
+        instancemetrics_db: (( grab meta.autoscaler.db ))
+        scalingengine_db: (( grab meta.autoscaler.db ))
+        policy_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        appmetrics_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        instancemetrics_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        scalingengine_db_connection_config: (( grab meta.autoscaler.db_connection_config ))
+        lock_db: (( grab meta.autoscaler.db ))
         require_consul: false
         operator:
           http_client_timeout: 60s
           app_sync_interval: 24h
           scaling_engine:
-            port: *scalingEnginePort
+            port: (( grab meta.autoscaler.scaling_engine_port ))
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/scalingengine_client:certificate" ))
-            client_key: (( vault meta.vault "/autoscaler/certs/scalingengine_client:key" ))        
+            client_key: (( vault meta.vault "/autoscaler/certs/scalingengine_client:key" ))
           scheduler:
-            port: *schedulerPort
+            port: (( grab meta.autoscaler.scheduler_port ))
             ca_cert: (( vault meta.vault "/autoscaler/certs/ca:certificate" ))
             client_cert: (( vault meta.vault "/autoscaler/certs/scheduler_client:certificate" ))
             client_key: (( vault meta.vault "/autoscaler/certs/scheduler_client:key" ))
-          db_lock: 
+          db_lock:
             ttl: 15s
             retry_interval: 5s
           enable_db_lock: false
           logging:
-            level: debug 
+            level: debug
           health:
-            port: &operatorHealthPort 6208          
+            port: (( grab meta.autoscaler.operator_health_port ))
 
 meta:
-  broker_url: (( grab params.autoscaler_broker_url || meta.broker_url_default ))
-  broker_url_default: (( concat "autoscalerservicebroker." params.system_domain ))
-  sb_port: (( grab params.autoscaler_servicebroker_port || 6101 ))
-  example_plan:
-  - id: autoscaler-example-plan-id
-    name: autoscaler-example-plan
-    description: This is the example service plan for the Auto-Scaling service.
+  autoscaler:
+    broker_url: (( grab params.autoscaler_broker_url || meta.autoscaler.broker_url_default ))
+    broker_url_default: (( concat "autoscalerservicebroker." params.system_domain ))
+    api_server_public_port: 6106
+    event_generator_health_port: 6205
+    event_generator_port: 6105
+    metrics_collector_health_port: 6203
+    metrics_collector_port: 6103
+    operator_health_port: 6208
+    scaling_engine_health_port: 6204
+    scaling_engine_port: 6104
+    scheduler_health_port: 6202
+    scheduler_port: 6102
+    servicebroker_port: (( grab params.autoscaler_servicebroker_port || 6101 ))
+
+    cf_credentials:
+      api: (( concat "https://" meta.api_hostname ))
+      grant_type: password
+      username: admin
+      password: (( vault meta.vault "/admin_user:password" ))
+      client_id: app_autoscaler
+      secret: (( vault meta.vault "/uaa/client_secrets:app_autoscaler" ))
+      skip_ssl_validation: (( grab params.skip_ssl_validation ))
+
+    db:
+      databases:
+      - name: autoscaler
+        tag: default
+      address: (( grab params.autoscalerdb_host || params.external_db_host ))
+      db_scheme: postgres
+      port: (( grab params.autoscalerdb_port || params.external_db_port ))
+      roles:
+      - name: (( grab params.autoscalerdb_user || params.external_db_username ))
+        password: (( grab params.autoscalerdb_password || params.external_db_password ))
+        tag: default
+      connection_config: (( grab meta.autoscaler.db_connection_config ))
+
+    db_connection_config:
+      max_open_connections: 100
+      max_idle_connections: 10
+      connection_max_lifetime: 60s
+
+    db_config:
+      idle_timeout: 1000
+      max_connections: 10
+      min_connections: 0
+
+    example_plan:
+    - id: autoscaler-example-plan-id
+      name: autoscaler-example-plan
+      description: This is the example service plan for the Auto-Scaling service.

--- a/manifests/addons/container-routing-integrity.yml
+++ b/manifests/addons/container-routing-integrity.yml
@@ -8,4 +8,16 @@ instance_groups:
           enabled: true
           require_and_verify_client_certificates: true
           trusted_ca_certificates: (( grab meta.certs.diego.ca ))
-          verify_subject_alt_name: gorouter.service.cf.internal
+          verify_subject_alt_name:
+            - gorouter.service.cf.internal
+            - ssh-proxy.service.cf.internal
+- name: access
+  jobs:
+  - name: ssh_proxy
+    properties:
+      backends:
+        tls:
+          enabled: true
+          ca_certificate: (( grab meta.certs.diego.ca ))
+          client_certificate: (( grab meta.certs.diego.ssh_proxy_backends_tls.client.cert ))
+          client_private_key: (( grab meta.certs.diego.ssh_proxy_backends_tls.client.key ))

--- a/manifests/addons/container-routing-integrity.yml
+++ b/manifests/addons/container-routing-integrity.yml
@@ -1,0 +1,11 @@
+instance_groups:
+- name: cell
+  jobs:
+  - name: rep
+    properties:
+      containers:
+        proxy:
+          enabled: true
+          require_and_verify_client_certificates: true
+          trusted_ca_certificates: (( grab meta.certs.diego.ca ))
+          verify_subject_alt_name: gorouter.service.cf.internal

--- a/manifests/addons/container-routing-integrity.yml
+++ b/manifests/addons/container-routing-integrity.yml
@@ -7,7 +7,8 @@ instance_groups:
         proxy:
           enabled: true
           require_and_verify_client_certificates: true
-          trusted_ca_certificates: (( grab meta.certs.diego.ca ))
+          trusted_ca_certificates:
+            - (( vault meta.vault "/diego/certs/instance_identity:certificate" ))
           verify_subject_alt_name:
             - gorouter.service.cf.internal
             - ssh-proxy.service.cf.internal

--- a/manifests/addons/loggregator-forwarder-agent.yml
+++ b/manifests/addons/loggregator-forwarder-agent.yml
@@ -33,3 +33,13 @@ addons:
     properties:
       grpc_port:   3459
       disable_udp: true
+
+  - name: loggr-expvar-forwarder
+    properties:
+      counters:
+        addr: http://127.0.0.1:14823/debug/vars
+        name: ingress
+        source_id: forwarder_agent
+        template: "{{.ForwarderAgent.IngressV2}}"
+        tags:
+          metric_version: "2.0"

--- a/manifests/addons/loggregator-forwarder-agent.yml
+++ b/manifests/addons/loggregator-forwarder-agent.yml
@@ -11,12 +11,6 @@ addons:
         ca_cert: (( grab meta.certs.loggregator.ca.certificate ))
         cert:    (( grab meta.certs.loggregator.forwarder_agent.certificate ))
         key:     (( grab meta.certs.loggregator.forwarder_agent.private_key ))
-      api:
-        tls:
-          ca_cert: (( grab meta.certs.diego.ca.certificate))
-          cert:    (( grab meta.certs.diego.forwarder_api_tls.certificate))
-          key:     (( grab meta.certs.diego.forwarder_api_tls.private_key))
-          cn:      "cloud-controller-ng.service.cf.internal"
 
 - name: udp_forwarder
   include:

--- a/manifests/addons/loggregator-forwarder-agent.yml
+++ b/manifests/addons/loggregator-forwarder-agent.yml
@@ -9,8 +9,8 @@ addons:
     properties:
       tls:
         ca_cert: (( grab meta.certs.loggregator.ca.certificate ))
-        cert:    (( grab meta.certs.loggregator.forwarder_agent.certificate ))
-        key:     (( grab meta.certs.loggregator.forwarder_agent.private_key ))
+        cert:    (( vault meta.vault "loggregator.forwarder_agent:certificate" ))
+        key:     (( vault meta.vault "loggregator.forwarder_agent:key" ))
 
 - name: udp_forwarder
   include:

--- a/manifests/addons/loggregator-forwarder-agent.yml
+++ b/manifests/addons/loggregator-forwarder-agent.yml
@@ -1,0 +1,41 @@
+addons:
+- name: forwarder_agent
+  include:
+    stemcell:
+    - os: ubuntu-xenial
+  jobs:
+  - name: loggr-forwarder-agent
+    release: loggregator-agent
+    properties:
+      tls:
+        ca_cert: (( grab meta.certs.loggregator.ca.certificate ))
+        cert:    (( grab meta.certs.loggregator.forwarder_agent.certificate ))
+        key:     (( grab meta.certs.loggregator.forwarder_agent.private_key ))
+      api:
+        tls:
+          ca_cert: (( grab meta.certs.diego.ca.certificate))
+          cert:    (( grab meta.certs.diego.forwarder_api_tls.certificate))
+          key:     (( grab meta.certs.diego.forwarder_api_tls.private_key))
+          cn:      "cloud-controller-ng.service.cf.internal"
+
+- name: udp_forwarder
+  include:
+    stemcell:
+    - os: ubuntu-xenial
+  jobs:
+  - name: loggr-udp-forwarder
+    release: loggregator-agent
+    properties:
+      loggregator:
+        ingress_port: 3459
+        tls:
+          ca_cert: (( grab meta.certs.loggregator.ca ))
+          cert: (( grab meta.certs.loggregator.metron.server.cert ))
+          key: (( grab meta.certs.loggregator.metron.server.key ))
+
+- name: loggregator_agent
+  jobs:
+  - name: loggregator_agent
+    properties:
+      grpc_port:   3459
+      disable_udp: true

--- a/manifests/addons/native-garden-runc.yml
+++ b/manifests/addons/native-garden-runc.yml
@@ -5,4 +5,4 @@ instance_groups:
     - name: garden
       properties:
         garden:
-          (( prune "experimental_containerd_mode" ))
+          (( prune "containerd_mode" ))

--- a/manifests/addons/native-garden-runc.yml
+++ b/manifests/addons/native-garden-runc.yml
@@ -1,0 +1,8 @@
+instance_groups:
+  - name: cell
+    jobs:
+    - (( delete "containerd" ))
+    - name: garden
+      properties:
+        garden:
+          (( prune "experimental_containerd_mode" ))

--- a/manifests/addons/native-garden-runc.yml
+++ b/manifests/addons/native-garden-runc.yml
@@ -1,8 +1,10 @@
+---
 instance_groups:
   - name: cell
     jobs:
-    - (( delete "containerd" ))
     - name: garden
       properties:
         garden:
-          (( prune "containerd_mode" ))
+          containerd_mode: (( prune ))
+    - name: containerd
+    - (( delete "containerd" ))

--- a/manifests/addons/nfs-volume-services.yml
+++ b/manifests/addons/nfs-volume-services.yml
@@ -1,4 +1,9 @@
 ---
+
+meta:
+  cc:
+    volume_services_enabled: true
+
 instance_groups:
   - name: cell
     jobs:
@@ -8,6 +13,6 @@ instance_groups:
 
 releases:
   - name: nfs-volume
-    version: 1.0.7
-    sha1: f609a25be32e1fc634e683cc3a89c0aaad1e70f0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/nfs-volume-release?v=1.0.7
+    version: 2.2.0
+    url: (( concat "https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=" releases.nfs-volume.version ))
+    sha1: 0302809949ab4978eb76d02f47f21ed8a68ea0f6

--- a/manifests/addons/nfs-volume-services.yml
+++ b/manifests/addons/nfs-volume-services.yml
@@ -12,7 +12,7 @@ instance_groups:
         release: nfs-volume
 
 releases:
-  - name: nfs-volume
-    version: 2.2.0
-    url: (( concat "https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=" releases.nfs-volume.version ))
-    sha1: 0302809949ab4978eb76d02f47f21ed8a68ea0f6
+  - name:    nfs-volume
+    version: "1.0.7"
+    url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/nfs-volume-release?v=" releases.nfs-volume.version ))
+    sha1:    f609a25be32e1fc634e683cc3a89c0aaad1e70f0

--- a/manifests/addons/nfs-volume-services.yml
+++ b/manifests/addons/nfs-volume-services.yml
@@ -1,5 +1,4 @@
 ---
-
 meta:
   cc:
     volume_services_enabled: true
@@ -8,11 +7,20 @@ instance_groups:
   - name: cell
     jobs:
       - (( append ))
-      - name: nfsv3driver
+
+      - name:    mapfs
+        release: mapfs
+
+      - name:    nfsv3driver
         release: nfs-volume
 
 releases:
   - name:    nfs-volume
-    version: "1.0.7"
-    url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/nfs-volume-release?v=" releases.nfs-volume.version ))
-    sha1:    f609a25be32e1fc634e683cc3a89c0aaad1e70f0
+    version: "2.3.0"
+    url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=" releases.nfs-volume.version ))
+    sha1:    8e104d7ed5be84258253476784b4d55650504125
+
+  - name:    mapfs
+    version: "1.2.0"
+    url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=" releases.mapfs.version ))
+    sha1:    0906df6efd4f785baea994c7d8fac9aad64f00b8

--- a/manifests/cf/access.yml
+++ b/manifests/cf/access.yml
@@ -22,6 +22,7 @@ instance_groups:
             require_ssl: true
             ca_cert: (( grab meta.certs.diego.ca ))
           enable_cf_auth: true
+          disable_healthcheck_server: true
           host_key: (( vault meta.vault "/ssh_proxy/host_key:private" ))
           uaa_secret: (( grab meta.uaa.ssh_proxy_secret ))
           uaa:

--- a/manifests/cf/addon-dns.yml
+++ b/manifests/cf/addon-dns.yml
@@ -1,4 +1,7 @@
 ---
+features:
+  use_dns_addresses: true
+
 addons:
 - (( append ))
 - name: bosh-dns-aliases

--- a/manifests/cf/addon-logging.yml
+++ b/manifests/cf/addon-logging.yml
@@ -33,35 +33,45 @@ addons:
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.Dropped}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.DroppedEgressV2}}"
         tags:
+          origin: loggregator.metron
           direction: egress
           metric_version: "2.0"
       - addr: http://127.0.0.1:14824/debug/vars
         name: dropped
         template: "{{.Agent.DroppedIngressV2}}"
         tags:
+          origin: loggregator.metron
           direction: ingress
           metric_version: "2.0"
 
       - addr: http://127.0.0.1:14824/debug/vars
         name: egress
         template: "{{.Agent.Egress}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: egress
         template: "{{.Agent.EgressV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
 
       - addr: http://127.0.0.1:14824/debug/vars
         name: ingress
         template: "{{.Agent.Ingress}}"
+        tags:
+          origin: loggregator.metron
       - addr: http://127.0.0.1:14824/debug/vars
         name: ingress
         template: "{{.Agent.IngressV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
 
       gauges:
@@ -70,12 +80,14 @@ addons:
         unit: bytes/minute
         template: "{{.Agent.AverageEnvelope}}"
         tags:
+          origin: loggregator.metron
           loggregator: v1
       - addr: http://127.0.0.1:14824/debug/vars
         name: average_envelopes
         unit: bytes/minute
         template: "{{.Agent.AverageEnvelopeV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"
           loggregator: v2
 
@@ -84,4 +96,5 @@ addons:
         unit: bytes/minute
         template: "{{.Agent.OriginMappingsV2}}"
         tags:
+          origin: loggregator.metron
           metric_version: "2.0"

--- a/manifests/cf/addon-logging.yml
+++ b/manifests/cf/addon-logging.yml
@@ -21,3 +21,67 @@ addons:
         deployment: (( grab name ))
       metron_endpoint:
         shared_secret: (( grab meta.loggregator.endpoint_secret ))
+  - name: loggr-expvar-forwarder
+    release: loggregator-agent
+    properties:
+      log_agent:
+        ca_cert: (( grab meta.certs.loggregator.ca ))
+        client_cert: (( grab meta.certs.loggregator.expvar_forwarder.cert ))
+        client_key: (( grab meta.certs.loggregator.expvar_forwarder.key ))
+      default_source_id: metron
+      counters:
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.Dropped}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.DroppedEgressV2}}"
+        tags:
+          direction: egress
+          metric_version: "2.0"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: dropped
+        template: "{{.Agent.DroppedIngressV2}}"
+        tags:
+          direction: ingress
+          metric_version: "2.0"
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: egress
+        template: "{{.Agent.Egress}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: egress
+        template: "{{.Agent.EgressV2}}"
+        tags:
+          metric_version: "2.0"
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: ingress
+        template: "{{.Agent.Ingress}}"
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: ingress
+        template: "{{.Agent.IngressV2}}"
+        tags:
+          metric_version: "2.0"
+
+      gauges:
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: average_envelopes
+        unit: bytes/minute
+        template: "{{.Agent.AverageEnvelope}}"
+        tags:
+          loggregator: v1
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: average_envelopes
+        unit: bytes/minute
+        template: "{{.Agent.AverageEnvelopeV2}}"
+        tags:
+          metric_version: "2.0"
+          loggregator: v2
+
+      - addr: http://127.0.0.1:14824/debug/vars
+        name: origin_mappings
+        unit: bytes/minute
+        template: "{{.Agent.OriginMappingsV2}}"
+        tags:
+          metric_version: "2.0"

--- a/manifests/cf/addon-logging.yml
+++ b/manifests/cf/addon-logging.yml
@@ -25,9 +25,9 @@ addons:
     release: loggregator-agent
     properties:
       log_agent:
-        ca_cert: (( grab meta.certs.loggregator.ca ))
-        client_cert: (( grab meta.certs.loggregator.expvar_forwarder.cert ))
-        client_key: (( grab meta.certs.loggregator.expvar_forwarder.key ))
+        ca_cert: (( vault meta.vault "/loggregator/certs/ca:certificate" ))
+        client_cert: (( vault meta.vault "/loggregator/certs/expvar_forwarder:certificate" ))
+        client_key: (( vault meta.vault "/loggregator/certs/expvar_forwarder:key" ))
       default_source_id: metron
       counters:
       - addr: http://127.0.0.1:14824/debug/vars

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -58,6 +58,8 @@ params:
   cell_instances:        3
   syslogger_instances:   2
 
+  vm_strategy: delete-create # also allows `create-swap-delete`
+
   nats_vm_type:        small
   uaa_vm_type:         medium
   api_vm_type:         medium
@@ -224,6 +226,7 @@ update:
   serial: false
   canary_watch_time: 30000-120000
   update_watch_time: 30000-120000
+  vm_strategy: (( grab params.vm_strategy ))
 
 stemcells:
   - alias: default

--- a/manifests/cf/buildpacks.yml
+++ b/manifests/cf/buildpacks.yml
@@ -1,45 +1,55 @@
 releases:
 - name:    binary-buildpack
-  version: "1.0.31"
+  version: "1.0.32"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=" releases.binary-buildpack.version ))
-  sha1:    2828671ec47424bbc06d609ef53eea3197a5ffd7
+  sha1:    5ab3b7e685ca18a47d0b4a16d0e3b60832b0a393
 
 - name:    dotnet-core-buildpack
-  version: "2.1.5"
+  version: "2.2.12"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=" releases.dotnet-core-buildpack.version ))
-  sha1:    188dace870c94749a3abc21cb538c08e0f4f3d8c
+  sha1:    ba037a288209a1d088ec717a006164f2baa99a7b
 
 - name:    go-buildpack
-  version: "1.8.28"
+  version: "1.8.39"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=" releases.go-buildpack.version ))
-  sha1:    cde33a1eda5392dd5c887d4d72568aabefb1f20a
+  sha1:    717ef8bf2032ca9aa814fe6f49070778e5bbb0a3
 
 - name:    java-buildpack
-  version: "4.16.1"
+  version: "4.19"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=" releases.java-buildpack.version ))
-  sha1:    2e24d3da499fc62fd3f012f13188e7e7e7857c2a
+  sha1:    7099d188d47517f0cb2725aa71b540605e4058b6
+
+- name:    nginx-buildpack
+  version: "1.0.13"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=" releases.nginx-buildpack.version ))
+  sha1:    a9f9464fac46617b415285e1f94ad6c36e55b2b8
 
 - name:    nodejs-buildpack
-  version: "1.6.32"
+  version: "1.6.51"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=" releases.nodejs-buildpack.version ))
-  sha1:    69c02ed7bfcc145447222b7366d6ad41c07d86e5
+  sha1:    a8104e1769cce2ba5a7ed9c775c9e046df21edc6
 
 - name:    php-buildpack
-  version: "4.3.61"
+  version: "4.3.77"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=" releases.php-buildpack.version ))
-  sha1:    9c5f9f040135fda81da44c6e1b0a1da878b04bfb
+  sha1:    06359e8512b40f8bc81300aca08e0a7ba77bc1af
 
 - name:    python-buildpack
-  version: "1.6.21"
+  version: "1.6.34"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=" releases.python-buildpack.version ))
-  sha1:    03b8618c5940889529e0aa6c129436e17c2a28d3
+  sha1:    941778b5b6fc0b60b5cba95315ae8f18aacdae65
+
+- name:    r-buildpack
+  version: "1.0.10"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=" releases.r-buildpack.version ))
+  sha1:    e7f40b13293c5f0b68d306729dabb54e1ee3c765
 
 - name:    ruby-buildpack
-  version: "1.7.24"
+  version: "1.7.40"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=" releases.ruby-buildpack.version ))
-  sha1:    d696be61e29dd0ea60129df148747831feece51f
+  sha1:    dd28168efe9efc463de830855cbab704b8f8b99e
 
 - name:    staticfile-buildpack
-  version: "1.4.32"
+  version: "1.4.43"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=" releases.staticfile-buildpack.version ))
-  sha1:    5851241b881f3315383fe4d2a50ca89fe2a5d331
+  sha1:    0f47a7035645bce994f64a5021f930a5eb246caf

--- a/manifests/cf/buildpacks.yml
+++ b/manifests/cf/buildpacks.yml
@@ -1,0 +1,45 @@
+releases:
+- name:    binary-buildpack
+  version: "1.0.31"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=" releases.binary-buildpack.version ))
+  sha1:    2828671ec47424bbc06d609ef53eea3197a5ffd7
+
+- name:    dotnet-core-buildpack
+  version: "2.1.5"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=" releases.dotnet-core-buildpack.version ))
+  sha1:    188dace870c94749a3abc21cb538c08e0f4f3d8c
+
+- name:    go-buildpack
+  version: "1.8.28"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=" releases.go-buildpack.version ))
+  sha1:    cde33a1eda5392dd5c887d4d72568aabefb1f20a
+
+- name:    java-buildpack
+  version: "4.16.1"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=" releases.java-buildpack.version ))
+  sha1:    2e24d3da499fc62fd3f012f13188e7e7e7857c2a
+
+- name:    nodejs-buildpack
+  version: "1.6.32"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=" releases.nodejs-buildpack.version ))
+  sha1:    69c02ed7bfcc145447222b7366d6ad41c07d86e5
+
+- name:    php-buildpack
+  version: "4.3.61"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=" releases.php-buildpack.version ))
+  sha1:    9c5f9f040135fda81da44c6e1b0a1da878b04bfb
+
+- name:    python-buildpack
+  version: "1.6.21"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=" releases.python-buildpack.version ))
+  sha1:    03b8618c5940889529e0aa6c129436e17c2a28d3
+
+- name:    ruby-buildpack
+  version: "1.7.24"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=" releases.ruby-buildpack.version ))
+  sha1:    d696be61e29dd0ea60129df148747831feece51f
+
+- name:    staticfile-buildpack
+  version: "1.4.32"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=" releases.staticfile-buildpack.version ))
+  sha1:    5851241b881f3315383fe4d2a50ca89fe2a5d331

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -8,10 +8,13 @@ instance_groups:
   - name: cflinuxfs3-rootfs-setup
     release: cflinuxfs3
 
+  - name: containerd
+    release: garden-runc
   - name: garden
     release: garden-runc
     properties:
       garden:
+        experimental_containerd_mode: true
         default_container_grace_time: 0
         destroy_containers_on_start: true
         cleanup_process_dirs_on_wait: true

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -17,9 +17,6 @@ instance_groups:
         cleanup_process_dirs_on_wait: true
         deny_networks:
         - 0.0.0.0/0
-        persistent_image_list:
-        - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
-        - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar
       grootfs:
         reserved_space_for_other_jobs_in_mb: (( grab params.grootfs_reserved_space || 15360 ))
 

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -1,12 +1,26 @@
 ---
+meta:
+  trusted_cas:
+    - (( vault meta.vault "/diego/certs/ca:certificate" ))
+
+params:
+  trusted_cas: []
+
 instance_groups:
 - name: cell
   jobs:
 
   - name: cflinuxfs2-rootfs-setup
     release: cflinuxfs2
+    properties:
+      cflinuxfs2-rootfs:
+        trusted_certs: (( join "\n" meta.trusted_cas params.trusted_cas ))
+
   - name: cflinuxfs3-rootfs-setup
     release: cflinuxfs3
+    properties:
+      cflinuxfs3-rootfs:
+        trusted_certs: (( join "\n" meta.trusted_cas params.trusted_cas ))
 
   - name: containerd
     release: garden-runc

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -14,7 +14,7 @@ instance_groups:
     release: garden-runc
     properties:
       garden:
-        experimental_containerd_mode: true
+        containerd_mode: true
         default_container_grace_time: 0
         destroy_containers_on_start: true
         cleanup_process_dirs_on_wait: true

--- a/manifests/cf/certs.yml
+++ b/manifests/cf/certs.yml
@@ -92,6 +92,11 @@ meta:
         server_cert: (( vault meta.vault "/diego/certs/locket_server:certificate" ))
         server_key: (( vault meta.vault "/diego/certs/locket_server:key" ))
 
+        ssh_proxy_backends_tls:
+          client:
+            cert: (( vault meta.vault "/diego/certs/ssh_proxy_backends_tls:certificate" ))
+            key: (( vault meta.vault "/diego/certs/ssh_proxy_backends_tls:key" ))
+
     loggregator:
       ca: (( vault meta.vault "/loggregator/certs/ca:certificate" ))
 

--- a/manifests/cf/certs.yml
+++ b/manifests/cf/certs.yml
@@ -62,6 +62,14 @@ meta:
           client_cert: (( vault meta.vault "/diego/certs/cc_uploader:certificate" ))
           client_key: (( vault meta.vault "/diego/certs/cc_uploader:key" ))
 
+      cc_deployment_updater:
+        server:
+          server_cert: (( vault meta.vault "/diego/certs/cc_deployment_updater_server:certificate" ))
+          server_key:  (( vault meta.vault "/diego/certs/cc_deployment_updater_server:key" ))
+        client:
+          server_cert: (( vault meta.vault "/diego/certs/cc_deployment_updater:certificate" ))
+          server_key:  (( vault meta.vault "/diego/certs/cc_deployment_updater:key" ))
+
       rep:
         server:
           server_cert: (( vault meta.vault "/diego/certs/rep:certificate" ))

--- a/manifests/cf/certs.yml
+++ b/manifests/cf/certs.yml
@@ -83,10 +83,6 @@ meta:
           cert: (( vault meta.vault "/diego/certs/syslogdrainbinder:certificate" ))
           key: (( vault meta.vault "/diego/certs/syslogdrainbinder:key" ))
 
-      forwarder_api_tls:
-        cert: (( vault meta.vault "/loggregator/certs/forwarder_api_tls:certificate" ))
-        key: (( vault meta.vault "/loggregator/certs/forwarder_api_tls:key" ))
-
       tps:
         client:
           client_cert: (( vault meta.vault "/diego/certs/rep_client:certificate" ))

--- a/manifests/cf/certs.yml
+++ b/manifests/cf/certs.yml
@@ -83,6 +83,10 @@ meta:
           cert: (( vault meta.vault "/diego/certs/syslogdrainbinder:certificate" ))
           key: (( vault meta.vault "/diego/certs/syslogdrainbinder:key" ))
 
+      forwarder_api_tls:
+        cert: (( vault meta.vault "/loggregator/certs/forwarder_api_tls:certificate" ))
+        key: (( vault meta.vault "/loggregator/certs/forwarder_api_tls:key" ))
+
       tps:
         client:
           client_cert: (( vault meta.vault "/diego/certs/rep_client:certificate" ))
@@ -109,6 +113,10 @@ meta:
         server:
           cert: (( vault meta.vault "/loggregator/certs/metron:certificate" ))
           key: (( vault meta.vault "/loggregator/certs/metron:key" ))
+
+      forwarder_agent:
+        cert: (( vault meta.vault "/loggregator/certs/forwarder_agent:certificate" ))
+        key: (( vault meta.vault "/loggregator/certs/forwarder_agent:key" ))
 
       logcache:
         cert: (( vault meta.vault "/loggregator/certs/log_cache:certificate" ))

--- a/manifests/cf/cloud_controller.yml
+++ b/manifests/cf/cloud_controller.yml
@@ -83,8 +83,8 @@ instance_groups:
         temporary_disable_deployments: (( grab meta.cc.temporary_disable_deployments ))
         mutual_tls:
           ca_cert: (( grab meta.certs.diego.ca ))
-          private_key: (( grab meta.certs.diego.cc_deployment_updater_server.key ))
-          public_cert: (( grab meta.certs.diego.cc_deployment_updater.cert ))
+          private_key: (( vault meta.vault "/diego/certs/cc_deployment_updater_server:key" ))
+          public_cert: (( vault meta.vault "/diego/certs/cc_deployment_updater:certificate" ))
       ccdb:
         .: (( inject meta.ccdb ))
 
@@ -157,6 +157,10 @@ meta:
     staging_upload_user:     staging_upload_user
     staging_upload_password: (( vault meta.vault "/cc:staging_upload" ))
     db_encryption_key:       (( vault meta.vault "/cc:db_encryption_key" ))
+    temporary_use_logcache:  true
+    logcache_tls:
+      certificate: (( vault meta.vault "/loggregator/certs/log_cache:certificate" ))
+      private_key: (( vault meta.vault "/loggregator/certs/log_cache:key" ))
     public_tls:
       ca_cert: (( grab meta.certs.diego.public_tls.certificate ))
       .: (( inject meta.certs.diego.public_tls ))
@@ -193,6 +197,8 @@ meta:
     - name: cflinuxfs3
       description: Cloud Foundry Linux-based filesystem (Ubuntu 18.04)
     default_stack: (( grab params.default_stack ))
+    diego:
+      docker_staging_stack: (( grab params.default_stack ))
     install_buildpacks:
     - name: staticfile_buildpack
       package: staticfile-buildpack-cflinuxfs2

--- a/manifests/cf/cloud_controller.yml
+++ b/manifests/cf/cloud_controller.yml
@@ -102,6 +102,7 @@ instance_groups:
     properties:
       uaa_client_secret: (( vault meta.vault "/uaa/client_secrets:network_policy" ))
       uaa_ca: (( grab meta.certs.uaa.ca ))
+      enable_space_developer_self_service: true
       database:
         type: (( grab params.policyserverdb_scheme ))
         username: (( grab params.policyserverdb_user ))

--- a/manifests/cf/cloud_controller.yml
+++ b/manifests/cf/cloud_controller.yml
@@ -75,6 +75,19 @@ instance_groups:
             scope: openid,cloud_controller_service_permissions.read
             secret: (( grab meta.uaa.cc_broker_secret ))
 
+  - name: cc_deployment_updater
+    release: capi
+    properties:
+      cc:
+        db_encryption_key: (( vault meta.vault "/cc:db_encryption_key" ))
+        temporary_disable_deployments: (( grab meta.cc.temporary_disable_deployments ))
+        mutual_tls:
+          ca_cert: (( grab meta.certs.diego.ca ))
+          private_key: (( grab meta.certs.diego.cc_deployment_updater_server.key ))
+          public_cert: (( grab meta.certs.diego.cc_deployment_updater.cert ))
+      ccdb:
+        .: (( inject meta.ccdb ))
+
   - name: statsd_injector
     release: statsd-injector
     properties: (( grab meta.statsd_injector ))
@@ -110,7 +123,7 @@ instance_groups:
         host: (( grab params.policyserverdb_host ))
         port: (( grab params.policyserverdb_port ))
         name: (( grab params.policyserverdb_name ))
-    
+
   - name: policy-server-internal
     release: cf-networking
     properties:
@@ -262,6 +275,7 @@ meta:
       rules: (( grab params.cf_public_ips ))
 
     volume_services_enabled: true
+    temporary_disable_deployments: (( grab params.temporary_disable_cc_deployments || "false" ))
 
   statsd_injector:
     enable_consul_service_registration: false

--- a/manifests/cf/cloud_controller.yml
+++ b/manifests/cf/cloud_controller.yml
@@ -158,6 +158,13 @@ meta:
     staging_upload_password: (( vault meta.vault "/cc:staging_upload" ))
     db_encryption_key:       (( vault meta.vault "/cc:db_encryption_key" ))
     temporary_use_logcache:  true
+
+    # we put log-cache on the LTC, not on the dopplers, so the
+    # default from the capi-release is insufficient
+    logcache:
+      host: loggregator-trafficcontroller.service.cf.internal
+      port: 8080
+
     logcache_tls:
       certificate: (( vault meta.vault "/loggregator/certs/log_cache:certificate" ))
       private_key: (( vault meta.vault "/loggregator/certs/log_cache:key" ))

--- a/manifests/cf/diego.yml
+++ b/manifests/cf/diego.yml
@@ -37,7 +37,6 @@ instance_groups:
     properties:
       capi:
         tps:
-          listener_enabled: false
           bbs:
             ca_cert: (( grab meta.certs.diego.ca ))
             .: (( inject meta.certs.diego.bbs.client ))

--- a/manifests/cf/loggregator.yml
+++ b/manifests/cf/loggregator.yml
@@ -63,6 +63,8 @@ instance_groups:
     properties:
       http:
         address: "0.0.0.0:8088"
+        cert: (( vault meta.vault "/loggregator/certs/rlp_gateway:certificate" ))
+        key:  (( vault meta.vault "/loggregator/certs/rlp_gateway:key" ))
       logs_provider:
         ca_cert:  (( grab meta.certs.loggregator.ca ))
         client_cert: (( grab meta.certs.loggregator.syslogger.rlp.cert ))

--- a/manifests/cf/loggregator.yml
+++ b/manifests/cf/loggregator.yml
@@ -232,7 +232,8 @@ instance_groups:
       route_registrar:
         routes:
         - name: doppler
-          port: 8081
+          tls_port: 8081
+          server_cert_domain_san: (( concat "doppler." params.system_domain ))
           registration_interval: 20s
           uris:
           - (( concat "doppler." params.system_domain ))

--- a/manifests/cf/loggregator.yml
+++ b/manifests/cf/loggregator.yml
@@ -36,6 +36,8 @@ instance_groups:
       ssl:
         skip_cert_verify: (( grab params.skip_ssl_validation ))
       loggregator:
+        outgoing_cert: (( grab meta.certs.loggregator.trafficcontroller.server.cert ))
+        outgoing_key: (( grab meta.certs.loggregator.trafficcontroller.server.key ))
         tls:
           ca_cert: (( grab meta.certs.loggregator.ca ))
           trafficcontroller: (( grab meta.certs.loggregator.trafficcontroller.server ))
@@ -82,7 +84,6 @@ instance_groups:
     provides:
       log-cache: {shared: true}
     properties:
-      egress_port: 8080
       health_addr: localhost:6060
       tls:
         ca_cert: (( grab meta.certs.loggregator.ca ))
@@ -173,6 +174,10 @@ instance_groups:
         source_id: log-cache
         addr: http://localhost:6060/debug/vars
         template: "{{.LogCache.AvailableSystemMemory}}"
+      - name: uptime
+        source_id: log-cache
+        addr: http://localhost:6060/debug/vars
+        template: "{{.LogCache.Uptime}}"
       - name: promql-instant-query-time
         source_id: log-cache
         addr: http://localhost:6060/debug/vars
@@ -211,6 +216,8 @@ instance_groups:
         ca_cert: (( grab meta.certs.diego.ca ))
         common_name: cloud-controller-ng.service.cf.internal
       proxy_port: 8083
+      external_cert: (( vault meta.vault "/loggregator/certs/log_cache:certificate" ))
+      external_key:  (( vault meta.vault "/loggregator/certs/log_cache:key" ))
       uaa:
         ca_cert: (( grab meta.certs.uaa.ca ))
         client_id: doppler
@@ -222,11 +229,6 @@ instance_groups:
     properties:
       route_registrar:
         routes:
-        - name: loggregator
-          port: 8080
-          registration_interval: 20s
-          uris:
-          - (( concat "loggregator." params.system_domain ))
         - name: doppler
           port: 8081
           registration_interval: 20s
@@ -235,7 +237,9 @@ instance_groups:
           - (( concat "*.doppler." params.system_domain ))
         - name: log-cache-reverse-proxy
           port: 8083
+          tls_port: 8083
           registration_interval: 20s
+          server_cert_domain_san: (( concat "log-cache." params.system_domain ))
           uris:
           - (( concat "log-cache." params.system_domain ))
           - (( concat "*.log-cache." params.system_domain ))

--- a/manifests/cf/releases.yml
+++ b/manifests/cf/releases.yml
@@ -1,90 +1,96 @@
 releases:
 - name:    bpm
-  version: "0.13.0"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=" releases.bpm.version ))
-  sha1:    4b6ebfdaa467c04855528172b099e565d679e0f5
+  version: "1.1.0"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=" releases.bpm.version ))
+  sha1:    82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
 
 - name:    capi
-  version: "1.70.0"
+  version: "1.83.0"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=" releases.capi.version ))
-  sha1:    bf66504c6479cff3754fb1e114e7ea45767db04c
+  sha1:    339e21175080d77e648e0181b394a6aa2679d271
 
 - name:    cf-networking
-  version: "2.17.0"
+  version: "2.23.0"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=" releases.cf-networking.version ))
-  sha1:    0088d75912db87c28084347dc488370a9aa9fad0
+  sha1:    d1e8982a26287edc239116c2013de098fb9e15a8
 
 - name:    cf-smoke-tests
+  version: "40.0.112"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=" releases.cf-smoke-tests.version ))
-  version: "40.0.5"
-  sha1:    6f6081d24490a82c5b9fea73283e0cfe21cbf207
+  sha1:    26a8c40836fe8b0168fd4f0b02260d9b70cec595
 
 - name:    cflinuxfs2
-  version: "1.242.0"
+  version: "1.286.0"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=" releases.cflinuxfs2.version ))
-  sha1:    99821c729c05646c203a684a15a0971a5af08e35
+  sha1:    cbee634a14c42b7f9be48506f6a551960cac1652
 
 - name:    cflinuxfs3
+  version: "0.113.0"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=" releases.cflinuxfs3.version ))
-  version: 0.51.0
-  sha1:    97d802e3dff2b9d464327a31c5b4e27d671c45ab
+  sha1:    5132bdcc0975d404033e9dafba9d2acea50085a4
 
+- name:    cf-cli
+  version: "1.16.0"
+  url:     (( concat "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=" releases.cf-cli.version ))
+  sha1:    fa5d89b88a07822665d82e00f1629b98935b17e8
+  
 - name:    diego
-  version: "2.19.0"
+  version: "2.34.0"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/diego-release?v=" releases.diego.version ))
-  sha1:    d71a7977786c8266ab5e31a13366d5b949a24f09
+  sha1:    2ef1517f78126e0ef079244a83941a83b6dd0731
 
-- name:    "garden-runc"
-  version: "1.18.3"
+- name:    garden-runc
+  version: "1.19.3"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=" releases.garden-runc.version ))
-  sha1:    "1aa15e644c6c0c6c7ec072bf668fe5d9bcc4c632"
+  sha1:    76810f5dd66d8320b344b3eca197c5b669a3a633
 
 - name:    loggregator
-  version: "104.0"
+  version: "105.5"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=" releases.loggregator.version ))
-  sha1:    fc9f722ab0d321427942ed36dae70a49f084f9cf
-
-- name:    nats
-  version: "26"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nats-release?v=" releases.nats.version ))
-  sha1:    2f2c27acdfff81f3519968921686522518ab5783
-
-- name:    routing
-  version: "0.182.0"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=" releases.routing.version ))
-  sha1:    6e341a527a0dd2c920b54dea82156ae9bc0b29eb
-
-- name:    statsd-injector
-  version: "1.4.0"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=" releases.statsd-injector.version ))
-  sha1:    25c1c7d6217709d5217d32f70a48f203b79d3a16
-
-- name:    cf-syslog-drain
-  version: "7.1"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=" releases.cf-syslog-drain.version ))
-  sha1:    7e9648f44c6513ea5cb84531c9c5d1ae0730f202
-
-- name:    uaa
-  version: "62.0"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=" releases.uaa.version ))
-  sha1:    4423bb02d1be2d3c2f212465f4598c9eb62a4b63
-
-- name:    silk
-  version: "2.17.0"
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=" releases.silk.version ))
-  sha1:    752a269d854ca3840b1ec5f6d664efb3901e73e5
+  sha1:    62b9210def7c5179f6088b9449f551f57f1a1ee8
 
 - name:    loggregator-agent
-  version: "2.3"
+  version: "3.9"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=" releases.loggregator-agent.version ))
-  sha1:    7532818b5d518b87b57cf36ddc2bf81758f606f9
+  sha1:    bf723af956a61c7b51db0ba535c871bad24dd289
+
+- name:    log-cache
+  version: "2.2.2"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=" releases.log-cache.version ))
+  sha1:    634dd3e134d0dac00f3f86beb00c06653579af4b
+
+- name:    nats
+  version: "27"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nats-release?v=" releases.nats.version ))
+  sha1:    9817e8e460b8619a99a0a0fbec8220dc12b2a6f5
+
+- name:    routing
+  version: "0.188.0"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=" releases.routing.version ))
+  sha1:    d3420851c470790e8980ff0c506f75e3e52c15d9
+
+- name:    statsd-injector
+  version: "1.10.0"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=" releases.statsd-injector.version ))
+  sha1:    255cfb2815e692576efd5caa082f5a48f6799ca0
+
+- name:    cf-syslog-drain
+  version: "10.2"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=" releases.cf-syslog-drain.version ))
+  sha1:    fe9fd8946c39554425b534cdb8ce14f3923a31f8
+
+- name:    uaa
+  version: "72.0"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=" releases.uaa.version ))
+  sha1:    7130e5ac640ed1e1f52c09e76995e4d0680f3b45
+
+- name:    silk
+  version: "2.23.0"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=" releases.silk.version ))
+  sha1:    ecd2f3f05a308ae1920d17f941e38be0a5ec5ee9
 
 - name:    bosh-dns-aliases
   version: "0.0.3"
   url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=" releases.bosh-dns-aliases.version ))
   sha1:    b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
 
-- name:    log-cache
-  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=" releases.log-cache.version ))
-  version: "2.0.2"
-  sha1:    1f52248096ce2263405f3c82278e4f2aaddf1599

--- a/manifests/cf/releases.yml
+++ b/manifests/cf/releases.yml
@@ -1,109 +1,90 @@
 releases:
-- name: binary-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.31
-  version: "1.0.31"
-  sha1: 2828671ec47424bbc06d609ef53eea3197a5ffd7
-- name: bpm
+- name:    bpm
   version: "0.13.0"
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.13.0
-  sha1: 4b6ebfdaa467c04855528172b099e565d679e0f5
-- name: capi
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=" releases.bpm.version ))
+  sha1:    4b6ebfdaa467c04855528172b099e565d679e0f5
+
+- name:    capi
   version: "1.70.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.70.0
-  sha1: bf66504c6479cff3754fb1e114e7ea45767db04c
-- name: cf-networking
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=" releases.capi.version ))
+  sha1:    bf66504c6479cff3754fb1e114e7ea45767db04c
+
+- name:    cf-networking
   version: "2.17.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.17.0
-  sha1: 0088d75912db87c28084347dc488370a9aa9fad0
-- name: cf-smoke-tests
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.5
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=" releases.cf-networking.version ))
+  sha1:    0088d75912db87c28084347dc488370a9aa9fad0
+
+- name:    cf-smoke-tests
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=" releases.cf-smoke-tests.version ))
   version: "40.0.5"
-  sha1: 6f6081d24490a82c5b9fea73283e0cfe21cbf207
-- name: cflinuxfs2
+  sha1:    6f6081d24490a82c5b9fea73283e0cfe21cbf207
+
+- name:    cflinuxfs2
   version: "1.242.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.242.0
-  sha1: 99821c729c05646c203a684a15a0971a5af08e35
-- name: cflinuxfs3
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.51.0
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=" releases.cflinuxfs2.version ))
+  sha1:    99821c729c05646c203a684a15a0971a5af08e35
+
+- name:    cflinuxfs3
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=" releases.cflinuxfs3.version ))
   version: 0.51.0
-  sha1: 97d802e3dff2b9d464327a31c5b4e27d671c45ab
-- name: diego
+  sha1:    97d802e3dff2b9d464327a31c5b4e27d671c45ab
+
+- name:    diego
   version: "2.19.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.19.0
-  sha1: d71a7977786c8266ab5e31a13366d5b949a24f09
-- name: dotnet-core-buildpack
-  version: "2.1.5"
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.1.5
-  sha1: 188dace870c94749a3abc21cb538c08e0f4f3d8c
-- name: "garden-runc"
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/diego-release?v=" releases.diego.version ))
+  sha1:    d71a7977786c8266ab5e31a13366d5b949a24f09
+
+- name:    "garden-runc"
   version: "1.18.3"
-  url: "https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.3"
-  sha1: "1aa15e644c6c0c6c7ec072bf668fe5d9bcc4c632"
-- name: go-buildpack
-  version: "1.8.28"
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.8.28
-  sha1: cde33a1eda5392dd5c887d4d72568aabefb1f20a
-- name: java-buildpack
-  version: "4.16.1"
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.16.1
-  sha1: 2e24d3da499fc62fd3f012f13188e7e7e7857c2a
-- name: loggregator
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=" releases.garden-runc.version ))
+  sha1:    "1aa15e644c6c0c6c7ec072bf668fe5d9bcc4c632"
+
+- name:    loggregator
   version: "104.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=104.0
-  sha1: fc9f722ab0d321427942ed36dae70a49f084f9cf
-- name: nats
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=" releases.loggregator.version ))
+  sha1:    fc9f722ab0d321427942ed36dae70a49f084f9cf
+
+- name:    nats
   version: "26"
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=26
-  sha1: 2f2c27acdfff81f3519968921686522518ab5783
-- name: nodejs-buildpack
-  version: "1.6.32"
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.6.32
-  sha1: 69c02ed7bfcc145447222b7366d6ad41c07d86e5
-- name: php-buildpack
-  version: "4.3.61"
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.3.61
-  sha1: 9c5f9f040135fda81da44c6e1b0a1da878b04bfb
-- name: python-buildpack
-  version: "1.6.21"
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.6.21
-  sha1: 03b8618c5940889529e0aa6c129436e17c2a28d3
-- name: routing
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nats-release?v=" releases.nats.version ))
+  sha1:    2f2c27acdfff81f3519968921686522518ab5783
+
+- name:    routing
   version: "0.182.0"
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.182.0
-  sha1: 6e341a527a0dd2c920b54dea82156ae9bc0b29eb
-- name: ruby-buildpack
-  version: "1.7.24"
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.7.24
-  sha1: d696be61e29dd0ea60129df148747831feece51f
-- name: staticfile-buildpack
-  version: "1.4.32"
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.4.32
-  sha1: 5851241b881f3315383fe4d2a50ca89fe2a5d331
-- name: statsd-injector
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=" releases.routing.version ))
+  sha1:    6e341a527a0dd2c920b54dea82156ae9bc0b29eb
+
+- name:    statsd-injector
   version: "1.4.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.4.0
-  sha1: 25c1c7d6217709d5217d32f70a48f203b79d3a16
-- name: cf-syslog-drain
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=" releases.statsd-injector.version ))
+  sha1:    25c1c7d6217709d5217d32f70a48f203b79d3a16
+
+- name:    cf-syslog-drain
   version: "7.1"
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=7.1
-  sha1: 7e9648f44c6513ea5cb84531c9c5d1ae0730f202
-- name: uaa
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=" releases.cf-syslog-drain.version ))
+  sha1:    7e9648f44c6513ea5cb84531c9c5d1ae0730f202
+
+- name:    uaa
   version: "62.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=62.0
-  sha1: 4423bb02d1be2d3c2f212465f4598c9eb62a4b63
-- name: silk
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=" releases.uaa.version ))
+  sha1:    4423bb02d1be2d3c2f212465f4598c9eb62a4b63
+
+- name:    silk
   version: "2.17.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.17.0
-  sha1: 752a269d854ca3840b1ec5f6d664efb3901e73e5
-- name: loggregator-agent
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/silk-release?v=" releases.silk.version ))
+  sha1:    752a269d854ca3840b1ec5f6d664efb3901e73e5
+
+- name:    loggregator-agent
   version: "2.3"
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=2.3
-  sha1: 7532818b5d518b87b57cf36ddc2bf81758f606f9
-- name: bosh-dns-aliases
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=" releases.loggregator-agent.version ))
+  sha1:    7532818b5d518b87b57cf36ddc2bf81758f606f9
+
+- name:    bosh-dns-aliases
   version: "0.0.3"
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-- name: log-cache
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.0.2
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=" releases.bosh-dns-aliases.version ))
+  sha1:    b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
+
+- name:    log-cache
+  url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=" releases.log-cache.version ))
   version: "2.0.2"
-  sha1: 1f52248096ce2263405f3c82278e4f2aaddf1599
+  sha1:    1f52248096ce2263405f3c82278e4f2aaddf1599

--- a/manifests/cf/smoke-tests.yml
+++ b/manifests/cf/smoke-tests.yml
@@ -8,8 +8,8 @@ instance_groups:
       smoke_tests:
         api: (( concat "https://api." params.system_domain ))
         apps_domain: (( grab params.apps_domains[0] ))
-        user:     (( grab meta.admin.user ))
-        password: (( grab meta.admin.password ))
+        client: cf_smoke_tests
+        client_secret: (( grab meta.uaa.cf_smoke_tests ))
         org: cf_smoke_tests_org
         space: cf_smoke_tests_space
         cf_dial_timeout_in_seconds: 300

--- a/manifests/cf/smoke-tests.yml
+++ b/manifests/cf/smoke-tests.yml
@@ -14,3 +14,6 @@ instance_groups:
         space: cf_smoke_tests_space
         cf_dial_timeout_in_seconds: 300
         skip_ssl_validation: (( grab params.skip_ssl_validation ))
+  - name: cf-cli-6-linux
+    release: cf-cli
+

--- a/manifests/cf/syslogger.yml
+++ b/manifests/cf/syslogger.yml
@@ -12,8 +12,6 @@ instance_groups:
             cert: (( grab meta.certs.loggregator.syslogger.server.cert ))
             key: (( grab meta.certs.loggregator.syslogger.server.key ))
             cn: ss-adapter
-          logs:
-            addr: reverse-log-proxy.service.cf.internal:8082
         adapter_rlp:
           tls:
             ca: (( grab meta.certs.loggregator.ca ))

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -72,7 +72,7 @@ instance_groups:
             autoapprove: true
             override: true
             redirect-uri: (( concat "https://uaa.system." params.system_domain "/login" ))
-            scope: openid,cloud_controller.read,cloud_controller.write
+            scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
             secret: (( grab meta.uaa.ssh_proxy_secret ))
           tcp_emitter:
             authorities: routing.routes.write,routing.routes.read,routing.router_groups.read

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -45,6 +45,10 @@ instance_groups:
             refresh-token-validity: (( grab meta.uaa.refresh_token_validity ))
             scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
             secret: ''
+          cf_smoke_tests:
+            authorities: cloud_controller.admin
+            authorized-grant-types: client_credentials
+            secret: (( grab meta.uaa.cf_smoke_tests ))
           cloud_controller_username_lookup:
             authorities: scim.userids
             authorized-grant-types: client_credentials
@@ -207,6 +211,7 @@ meta:
     tcp_emitter_secret:    (( vault meta.vault "/uaa/client_secrets:tcp_emitter" ))
     tcp_router_secret:     (( vault meta.vault "/uaa/client_secrets:tcp_router" ))
     network_policy_secret: (( vault meta.vault "/uaa/client_secrets:network_policy" ))
+    cf_smoke_tests:        (( vault meta.vault "/uaa/client_secrets:cf_smoke_tests" ))
 
     jwt_private_key:  (( vault meta.vault "/uaa/jwt_signing_key:private" ))
     ssl_cert:         (( grab meta.certs.uaa.server.cert ))

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -43,7 +43,7 @@ instance_groups:
             authorized-grant-types: password,refresh_token
             override: true
             refresh-token-validity: (( grab meta.uaa.refresh_token_validity ))
-            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin
+            scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin,clients.read
             secret: ''
           cf_smoke_tests:
             authorities: cloud_controller.admin
@@ -115,7 +115,7 @@ instance_groups:
         sslCertificate: (( grab meta.uaa.ssl_cert ))
         sslPrivateKey: (( grab meta.uaa.ssl_key ))
         url: (( grab meta.uaa.url ))
-        port: (( grab meta.uaa.port ))
+        port: 8080
         ssl:
           port: (( grab meta.uaa.ssl_port ))
         zones:
@@ -157,7 +157,9 @@ instance_groups:
       route_registrar:
         routes:
         - name: uaa
-          port: (( grab meta.uaa.port ))
+          tls_port: (( grab meta.uaa.ssl_port ))
+          servier_cert_domain_san: uaa.service.cf.internal
+
           registration_interval: 10s
           tags:
             component: uaa
@@ -188,10 +190,8 @@ meta:
 
   uaa:
     url: (( concat "https://uaa." params.system_domain ))
-    internal_url: "https://uaa.service.cf.internal:8443"
-    port: 8080
     ssl_port: 8443
-
+    internal_url: "https://uaa.service.cf.internal:8443"
     failure_count:         (( grab params.uaa_lockout_failure_count          || 5 ))
     failure_timeout:       (( grab params.uaa_lockout_punishment_time        || 300 ))
     time_between_failures: (( grab params.uaa_lockout_time_between_failures  || 1200 ))

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -199,6 +199,7 @@ meta:
     refresh_token_validity: (( grab params.uaa_refresh_token_validity        || 2592000 ))
 
     admin_client_secret:   (( vault meta.vault "/uaa/client_secrets:admin_client" ))
+    app_autoscaler:        (( vault meta.vault "/uaa/client_secrets:app_autoscaler" ))
     cc_broker_secret:      (( vault meta.vault "/uaa/client_secrets:cc_broker" ))
     cc_routing_secret:     (( vault meta.vault "/uaa/client_secrets:cc_routing" ))
     cc_service_key_client_secret: (( vault meta.vault "/uaa/client_secrets:cc_service_key_client" ))

--- a/manifests/db/local.yml
+++ b/manifests/db/local.yml
@@ -50,10 +50,10 @@ params:
   locketdb_port:     5432
 
 releases:
-- name: postgres
-  version: 3.1.5
-  url: https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.1.5/postgres-3.1.5.tgz
-  sha1: 30feaf3522b205812f3d363380dee57d20e5e32a
+- name:    postgres
+  version: 3.2.0
+  url:     https://github.com/cloudfoundry-community/postgres-boshrelease/releases/download/v3.2.0/postgres-3.2.0.tgz
+  sha1:    470c2b6d98d988ad9dc36dedcd8133e247de63f7
 
 instance_groups:
   - (( insert after "nats" ))

--- a/manifests/routing/haproxy.yml
+++ b/manifests/routing/haproxy.yml
@@ -1,7 +1,7 @@
 ---
 params:
   internal_only_domains: []
-  trusted_domain_cidrs: ""
+  trusted_domain_cidrs: ~
 
   haproxy_instances: 2
   haproxy_vm_type:   small

--- a/manifests/routing/haproxy.yml
+++ b/manifests/routing/haproxy.yml
@@ -40,7 +40,7 @@ instance_groups:
             tcp_link_port: 2222
 
 releases:
-  - name: haproxy
-    version: 9.3.0
-    url: https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/download/v9.3.0/haproxy-9.3.0.tgz
-    sha1: 384de4ad378b940641a34cda1c63fdc02c901b8f
+  - name:    haproxy
+    version: "9.7.1"
+    url:     (( concat "https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=" releases.haproxy.version ))
+    sha1:    a5bc4f04f212a26bbe8f36f339a751d7773eb223


### PR DESCRIPTION
# Major Update

This release brings the releases used by the CF Genesis Kit up to date with
[v9.5.0 of the cf-deployment release][cfd-9.5.0].  This release is
upgradable from the previous releases (assuming you go through the removal
of `consul` as per releases v1.3.x - v1.5.x of this kit).

[cfd-9.5.0]: https://github.com/cloudfoundry/cf-deployment/releases/tag/v9.5.0

# Improvements

- Space Developers are now able to set up network policies without platform
  operator involvement.

- Containerd is now the default containerization runtime for Diego, instead
  of garden/runc.  If you want the old behavior, you can specify the
  `native-garden-runc` feature.

- You can now set the VM update strategy via the `vm_strategy` param.

- gorouter and access VMs now provide shared BOSH links.

- App Autoscaler has been fixed and upgraded to 2.0.0, thanks to
  [anishp55][pr54].

- NFS Volume Services has been upgraded to v2.3.0 (see below for details).

- Consul has been officially removed (see below for details).

- Significant improvements to move communications to TLS

- Additional loggregator metrics

[pr54]: https://github.com/genesis-community/cf-genesis-kit/pull/54


## NFS Volume Services

NFS Volume Services, which can be enabled via the `nfs-volume-services` feature,
has been upgraded to v2.3.0.  This should be paired with the [updated
nfs-broker genesis kit][nfsbroker-0.2.0]

[nfsbroker-0.2.0]: https://github.com/genesis-community/nfs-broker-genesis-kit/releases/tag/v0.2.0

## Regarding Consul Deprecation

Consul is no longer supported, and was removed in release v1.5.0.  While
replacing consul with BOSH DNS was optional since v1.3.0 using the feature
`migrate-1.3-without-consul`, that feature is no longer necessary..

You should be able to directly upgrade to this version with no impact to your
existing Cloud Foundry system.  We recommend that you validate by upgrading
to v1.4.1 with `migrate-1.3.1-without-consul` enabled so that if something
does break, you can redeploy without that feature.

You must [enable BOSH DNS](https://bosh.io/docs/dns/#enable) in your BOSH
deployment via runtime config
[(example)](https://github.com/cloudfoundry/bosh-deployment/blob/master/runtime-configs/dns.yml)
to deploy this version.


# Core Components

| Release | Version | Release Date |
| ------- | ------- | ------------ |
| app-autoscaler | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019 |
| bosh-dns-aliases | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3) | 24 October 2018 |
| bpm | [1.1.0](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.0) | 28 May 2019 |
| capi | [1.83.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.83.0) | 28 June 2019 |
| cf-cli | [1.16.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.16.0) | 04 June 2019 |
| cf-networking | [2.23.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.23.0) | 17 June 2019 |
| cf-smoke-tests | [40.0.112](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/v40.0.112) | - |
| cf-syslog-drain | [10.2](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2) | 13 May 2019 |
| cflinuxfs2 | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0) | 12 June 2019 |
| cflinuxfs3 | [0.113.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.113.0) | 08 July 2019 |
| diego | [2.34.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.34.0) | 02 July 2019 |
| garden-runc | [1.19.3](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.3) | 25 June 2019 |
| haproxy | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1) | 05 September 2019 |
| log-cache | [2.2.2](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.2.2) | 31 May 2019 |
| loggregator | [105.5](https://github.com/cloudfoundry/loggregator-release/releases/tag/v105.5) | 06 May 2019 |
| loggregator-agent | [3.9](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v3.9) | 15 March 2019 |
| mapfs | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0) | 15 July 2019 |
| nats | [27](https://github.com/cloudfoundry/nats-release/releases/tag/v27) | 16 May 2019 |
| nfs-volume | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0) | 21 August 2019 |
| postgres | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0) | 19 September 2019 |
| routing | [0.188.0](https://github.com/cloudfoundry-incubator/cf-routing-release/releases/tag/0.188.0) | 12 April 2019 |
| silk | [2.23.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.23.0) | 17 June 2019 |
| statsd-injector | [1.10.0](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.10.0) | 16 April 2019 |
| uaa | [72.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v72.0) | 14 May 2019 |


# Buildpacks

| Release | Version | Release Date |
| ------- | ------- | ------------ |
| binary | [1.0.32](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.32) | 01 May 2019 |
| dotnet-core | [2.2.12](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.2.12) | 14 June 2019 |
| go | [1.8.39](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.8.39) | 01 May 2019 |
| java | [4.19](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.19) | 26 April 2019 |
| nginx | [1.0.13](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.0.13) | 14 June 2019 |
| nodejs | [1.6.51](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.6.51) | 14 June 2019 |
| php | [4.3.77](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.3.77) | 14 June 2019 |
| python | [1.6.34](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.6.34) | 14 June 2019 |
| r | [1.0.10](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.0.10) | 14 June 2019 |
| ruby | [1.7.40](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.7.40) | 14 June 2019 |
| staticfile | [1.4.43](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.4.43) | 14 June 2019 |

