### PR TITLE
No Static IPs (within reason)

### DIFF
--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -109,7 +109,6 @@ instance_groups:
     stemcell: default
     networks:
       - name: (( grab params.cf_internal_network ))
-        static_ips: (( static_ips 0 1 2 3 4 ))
 
   - name: api
     instances: (( grab params.api_instances ))
@@ -136,7 +135,6 @@ instance_groups:
     stemcell: default
     networks:
     - name: (( grab params.cf_internal_network ))
-      static_ips: (( static_ips 5 6 7 8 9 ))
 
   - name: syslogger
     instances: (( grab params.syslogger_instances ))

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -163,7 +163,6 @@ instance_groups:
     stemcell: default
     networks:
     - name: (( grab params.cf_edge_network ))
-      static_ips: (( static_ips 0 1 2 3 4 ))
 
   - name: bbs
     instances: (( grab params.bbs_instances ))
@@ -190,7 +189,6 @@ instance_groups:
     stemcell: default
     networks:
       - name: (( grab params.cf_edge_network ))
-        static_ips: (( static_ips 5 6 7 8 9 ))
     vm_extensions:
       - ssh-elb
     migrated_from:

--- a/manifests/cf/nats.yml
+++ b/manifests/cf/nats.yml
@@ -14,6 +14,5 @@ instance_groups:
             prof_port:    0
             port:         4222
 
-            machines: (( grab instance_groups.nats.networks[0].static_ips ))
             user:     nats_user
             password: (( vault meta.vault "/nats:password" ))

--- a/manifests/routing/haproxy-tls.yml
+++ b/manifests/routing/haproxy-tls.yml
@@ -13,11 +13,3 @@ instance_groups:
             disable_tls_11: (( grab params.disable_tls_11 ))
 
             ssl_pem: (( vault meta.vault "/haproxy/ssl:combined" ))
-
-            tcp:
-              - (( append ))
-              - name: wss
-                port: 4443
-                ssl: true
-                backend_servers: (( grab instance_groups.router.networks[0].static_ips ))
-                backend_port: 80

--- a/manifests/routing/haproxy.yml
+++ b/manifests/routing/haproxy.yml
@@ -15,8 +15,9 @@ instance_groups:
   - (( insert before "nats" ))
   - name: haproxy
     instances: (( grab params.haproxy_instances ))
-    vm_type: (( grab params.haproxy_vm_type ))
-    azs: (( grab params.availability_zones || meta.default.azs ))
+    vm_type:   (( grab params.haproxy_vm_type ))
+    azs:       (( grab params.availability_zones || meta.default.azs ))
+
     stemcell: default
     networks:
       - name: (( grab params.cf_edge_network ))
@@ -29,9 +30,12 @@ instance_groups:
     jobs:
       - name: haproxy
         release: haproxy
+        consumes:
+          http_backend: { from: gorouter  }
+          tcp_backend:  { from: ssh-proxy }
+
         properties:
           ha_proxy:
-            backend_servers: (( grab instance_groups.router.networks[0].static_ips ))
             internal_only_domains: (( grab params.internal_only_domains ))
             trusted_domain_cidrs:  (( grab params.trusted_domain_cidrs ))
             ssl_pem: ~


### PR DESCRIPTION
This PR removes the static IP assignments for `doppler`, `router`, `access`, and `nats` instance groups, instead relying entirely on BOSH links for wiring things back up.