### PR TITLE
add evacuation_timeout as params, default to 10 mins

### DIFF
--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -5,6 +5,7 @@ meta:
 
 params:
   trusted_cas: []
+  evacuation_timeout: 600
 
 instance_groups:
   - name: cell
@@ -53,7 +54,7 @@ instance_groups:
           rep:
             .: (( inject meta.certs.diego.rep.server ))
             enable_legacy_api_endpoints: false
-            evacuation_timeout_in_seconds: 60
+            evacuation_timeout_in_seconds: (( grab params.evacuation_timeout ))
             listen_addr_admin: ~
             preloaded_rootfses:
               - cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar


### PR DESCRIPTION
The 1 min default evacuation timeout did not work well when the apps took more than one minute to get replaced during an upgrade for example. The reasons can be found in this link
https://docs.cloudfoundry.org/running/diego-upgrades.html
specifically in the following para
```
The evacuating cells continue to interact with the Diego system as replacements come online. The cell undergoing upgrade waits until either its app instance replacements run successfully before shutting down the original local instances, or for the evacuation process to time out. This “evacuation timeout” defaults to 10 minutes.

If cell evacuation exceeds this timeout, then the cell stops its app instances and shuts down. The Diego system continues to re-emit start requests for the app replacements.
```
The git history for bumping this value in Diego release is here
https://github.com/cloudfoundry/diego-release/commit/4628d37d39a24a38fc84ea2743b32e282b05dd95