### PR TITLE
Routing api

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -410,6 +410,14 @@ Certificates will then be automatically generated with the proper
 subject alternate names for all of the domains (system and apps)
 that Cloud Foundry will use.
 
+### Enabling the Routing API
+
+The routing API for Cloud Foundry allows router groups to be queried in the
+Cloud Foundry API. This may be necessary if you are using cf-mgmt. The routing
+API can be enabled by specifying the `routing-api` feature in the kit.
+
+If the routing API is enabled and you are using an external database, you will
+need to ensure that the `routingapidb` is created.
 
 ## DNS-Based Service Discovery
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -18,7 +18,8 @@ validate_features nfs-volume-services small-footprint \
                   native-garden-runc \
                   loggregator-forwarder-agent \
                   cflinuxfs2 \
-                  app-bosh-dns dns-service-discovery
+                  app-bosh-dns dns-service-discovery \
+                  routing-api
 
 merge=( manifests/cf/base.yml
         manifests/cf/releases.yml
@@ -153,7 +154,7 @@ fi
 
 for want in ${GENESIS_REQUESTED_FEATURES}; do
   case "$want" in
-  azure|nfs-volume-services|container-routing-integrity|native-garden-runc|loggregator-forwarder-agent|cflinuxfs2|dns-service-discovery)
+  azure|nfs-volume-services|container-routing-integrity|native-garden-runc|loggregator-forwarder-agent|cflinuxfs2|dns-service-discovery|routing-api)
     merge+=( manifests/addons/$want.yml )
     ;;
 

--- a/kit.yml
+++ b/kit.yml
@@ -115,6 +115,9 @@ certificates:
       ssh_proxy_backends_tls:
         valid_for: 1y
         names: [ "ssh_proxy_backends_tls", "ssh-proxy.service.cf.internal" ]
+      routingapi_client:
+        valid_for: 1y
+        names: ["routing-api locket client"]
 
     diego/certs/instance_identity:
       ca: { valid_for: 1y }
@@ -250,6 +253,16 @@ certificates:
         valid_for: 1y
         names: [ "eventgenerator client" ]
 
+  routing-api:
+    routingapi/certs:
+      ca: {valid_for: 1y}
+      server:
+        valid_for: 1y
+        names: ["routing-api.service.cf.internal"]
+      client:
+        valid_for: 1y
+        names: ["routing-api client"]
+
 credentials:
   base:
     consul/encryption_key:
@@ -324,6 +337,8 @@ credentials:
     cfnetworkingdb:
       password: random 64
     locketdb:
+      password: random 64
+    routingapidb:
       password: random 64
 
   autoscaler:

--- a/manifests/addons/routing-api.yml
+++ b/manifests/addons/routing-api.yml
@@ -1,0 +1,55 @@
+meta:
+  cc:
+    routing_api:
+      routing_api:
+        enabled: true
+      uaa:
+        clients:
+          cc_routing:
+            secret: (( grab meta.uaa.cc_routing_secret ))
+
+instance_groups:
+- name: api
+  jobs:
+  - name: cloud_controller_ng
+    properties:
+      .: (( inject meta.cc.routing_api ))
+  - name: cloud_controller_worker
+    properties:
+      .: (( inject meta.cc.routing_api ))
+  - name: cloud_controller_clock
+    properties:
+      .: (( inject meta.cc.routing_api ))
+  - name: routing-api
+    release: routing
+    properties:
+      routing_api:
+        mtls_ca:          (( vault meta.vault "/routingapi/certs/ca:certificate" ))
+        mtls_server_cert: (( vault meta.vault "/routingapi/certs/server:certificate" ))
+        mtls_server_key:  (( vault meta.vault "/routingapi/certs/server:key" ))
+        mtls_client_cert: (( vault meta.vault "/routingapi/certs/client:certificate" ))
+        mtls_client_key:  (( vault meta.vault "/routingapi/certs/client:key" ))
+        skip_consul_lock: true
+        system_domain:    (( grab params.system_domain ))
+        sqldb: 
+          host:     (( grab params.routingapidb_host ))
+          type:     (( grab params.routingapidb_scheme )) 
+          port:     (( grab params.routingapidb_port ))
+          schema:   (( grab params.routingapidb_name ))
+          username: (( grab params.routingapidb_user ))
+          password: (( grab params.routingapidb_password ))
+        locket:
+          api_location: "locket.service.cf.internal:8891"
+          ca_cert:      (( vault meta.vault "/diego/certs/ca:certificate" ))
+          client_cert:  (( vault meta.vault "/diego/certs/routingapi_client:certificate" ))
+          client_key:   (( vault meta.vault "/diego/certs/routingapi_client:key" ))
+      uaa:
+        tls_port: (( grab instance_groups.uaa.jobs.uaa.properties.uaa.ssl.port ))
+        ca_cert:  (( grab meta.certs.uaa.ca ))
+
+- name: router
+  jobs:
+  - name: gorouter
+    properties:
+      routing_api:
+        enabled: true

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -117,6 +117,18 @@ instance_groups:
     networks:
     - name: (( grab params.cf_internal_network ))
 
+  - name: bbs
+    instances: (( grab params.bbs_instances ))
+    vm_type: (( grab params.bbs_vm_type ))
+    azs: (( grab params.availability_zones || meta.default.azs ))
+    stemcell: default
+    networks:
+      - name: (( grab params.cf_internal_network ))
+    migrated_from:
+      - name: diego-api
+    update:
+      serial: true
+
   - name: api
     instances: (( grab params.api_instances ))
     vm_type: (( grab params.api_vm_type ))
@@ -152,16 +164,6 @@ instance_groups:
     - name: (( grab params.cf_internal_network ))
     migrated_from:
     - name: log-api
-
-  - name: bbs
-    instances: (( grab params.bbs_instances ))
-    vm_type: (( grab params.bbs_vm_type ))
-    azs: (( grab params.availability_zones || meta.default.azs ))
-    stemcell: default
-    networks:
-      - name: (( grab params.cf_internal_network ))
-    migrated_from:
-      - name: diego-api
 
   - name: router
     instances: (( grab params.router_instances ))

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -109,6 +109,14 @@ instance_groups:
     networks:
       - name: (( grab params.cf_internal_network ))
 
+  - name: uaa
+    instances: (( grab params.uaa_instances ))
+    vm_type: (( grab params.uaa_vm_type ))
+    azs: (( grab params.availability_zones || meta.default.azs ))
+    stemcell: default
+    networks:
+    - name: (( grab params.cf_internal_network ))
+
   - name: api
     instances: (( grab params.api_instances ))
     vm_type: (( grab params.api_vm_type ))
@@ -118,14 +126,6 @@ instance_groups:
     - name: (( grab params.cf_internal_network ))
     update:
       serial: true
-
-  - name: uaa
-    instances: (( grab params.uaa_instances ))
-    vm_type: (( grab params.uaa_vm_type ))
-    azs: (( grab params.availability_zones || meta.default.azs ))
-    stemcell: default
-    networks:
-    - name: (( grab params.cf_internal_network ))
 
   - name: doppler
     instances: (( grab params.doppler_instances ))

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -96,22 +96,11 @@ params:
   locketdb_name: locketdb
   silkdb_name: silkdb
   policyserverdb_name:  policyserverdb
+  routingapidb_name:  routingapidb
 
   autoscaler_network: cf-autoscaler
 
 instance_groups:
-  - name: router
-    instances: (( grab params.router_instances ))
-    vm_type: (( grab params.router_vm_type ))
-    vm_extensions:
-      - cf-load-balanced
-    azs: (( grab params.availability_zones || meta.default.azs ))
-    stemcell: default
-    networks:
-      - name: (( grab params.cf_edge_network ))
-    update:
-      vm_strategry: create-swap-delete
-
   - name: nats
     instances: (( grab params.nats_instances ))
     vm_type: (( grab params.nats_vm_type ))
@@ -173,6 +162,18 @@ instance_groups:
       - name: (( grab params.cf_internal_network ))
     migrated_from:
       - name: diego-api
+
+  - name: router
+    instances: (( grab params.router_instances ))
+    vm_type: (( grab params.router_vm_type ))
+    vm_extensions:
+      - cf-load-balanced
+    azs: (( grab params.availability_zones || meta.default.azs ))
+    stemcell: default
+    networks:
+      - name: (( grab params.cf_edge_network ))
+    update:
+      vm_strategy: create-swap-delete
 
   - name: diego # metron, auctioneer, tps, cc_uploader, route_emitter
     instances: (( grab params.diego_instances ))

--- a/manifests/db/local-ha.yml
+++ b/manifests/db/local-ha.yml
@@ -7,6 +7,7 @@ params:
   policyserverdb_host: (( grab params.postgres_vip ))
   locketdb_host:       (( grab params.postgres_vip ))
   silkdb_host:         (( grab params.postgres_vip ))
+  routingapi_host:     (( grab params.postgres_vip ))
 
 instance_groups:
   - name: postgres

--- a/manifests/db/local.yml
+++ b/manifests/db/local.yml
@@ -49,6 +49,13 @@ params:
   locketdb_password: (( vault meta.vault "/autoscalerdb:password" ))
   locketdb_port:     5432
 
+  routingapidb_name:     routingapidb
+  routingapidb_host:     (( grab instance_groups.postgres.networks[0].static_ips[0] ))
+  routingapidb_user:     routingapiadmin
+  routingapidb_scheme:   postgres
+  routingapidb_password: (( vault meta.vault "/routingapidb:password" ))
+  routingapidb_port:     5432
+
 releases:
   - name:    postgres
     version: "3.2.0"
@@ -102,6 +109,9 @@ instance_groups:
               - username: (( grab params.locketdb_user ))
                 password: (( grab params.locketdb_password ))
 
+              - username: (( grab params.routingapidb_user ))
+                password: (( grab params.routingapidb_password ))
+
               - username: shield
                 password: (( vault meta.vault "/shield:password" ))
                 admin: true
@@ -131,7 +141,10 @@ instance_groups:
                 users:      [(( grab params.locketdb_user ))]
                 extensions: [citext, pgcrypto]
 
-
               - name:        (( grab params.silkdb_name ))
                 users:      [(( grab params.silkdb_user ))]
+                extensions: [citext, pgcrypto]
+
+              - name:        (( grab params.routingapidb_name ))
+                users:      [(( grab params.routingapidb_user ))]
                 extensions: [citext, pgcrypto]

--- a/manifests/db/mysql.yml
+++ b/manifests/db/mysql.yml
@@ -42,4 +42,10 @@ params:
   locketdb_scheme:   (( grab params.external_db_scheme ))
   locketdb_port:     (( grab params.external_db_port ))
 
+  routingapidb_host:     (( grab params.external_db_host ))
+  routingapidb_user:     (( grab params.external_db_username ))
+  routingapidb_password: (( grab params.external_db_password ))
+  routingapidb_scheme:   (( grab params.external_db_scheme ))
+  routingapidb_port:     (( grab params.external_db_port ))
+
   diegodb_connection_string: (( concat params.diegodb_user ":" params.diegodb_password "@tcp(" params.diegodb_host ":" params.diegodb_port ")/" params.diegodb_name ))

--- a/manifests/db/postgres.yml
+++ b/manifests/db/postgres.yml
@@ -41,4 +41,10 @@ params:
   locketdb_scheme:   postgres
   locketdb_port:     (( grab params.external_db_port ))
 
+  routingapidb_host:     (( grab params.external_db_host ))
+  routingapidb_user:     (( grab params.external_db_username ))
+  routingapidb_password: (( grab params.external_db_password ))
+  routingapidb_scheme:   postgres
+  routingapidb_port:     (( grab params.external_db_port ))
+
   diegodb_connection_string: (( concat params.diegodb_scheme "://" params.diegodb_user ":" params.diegodb_password "@" params.diegodb_host ":" params.diegodb_port "/" params.diegodb_name ))


### PR DESCRIPTION
Adds the routing api to CF as an addon.

Includes:
* Introduces the `routing-api` feature for the kit.
* Added a new database / user for the routing api.
* Moves router earlier in the update order, as router now potentially has a dependency on routing-api (on the api node)
* Moved UAA and BBS VMs earlier in the update order, as routing-api has a dependency on Locket and UAA.
* Cloud Controller Clock is now configured to know about the cc-routing UAA client. Cloud Controller NG and Cloud Controller Worker already did.
* Added CA, Server, and Client certs for mutual TLS to the routing API.
* Added a locket client certificate for the routing-api to use.

While I was in the neighborhood: Fixes #95 

You may be wondering: why can't the routing API go on the router? The router finds the routing API by its DNS name, provided by BOSH DNS. The router won't start until it connects to the routing-api, and BOSH DNS won't expose the IP of a service until its corresponding instance has been started. Because of this, the router would never start because the IP is not returned by DNS, and the IP will never be returned by DNS because the router will never start.