### PR TITLE
1.9.0 release candidate

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,5 @@
 2018-08-02 loosely integrate cf-deployment as of 2118b5d
 2018-10-19 loosely integrate cf-deployment as of b7dc33b
-2019-10-02 loosely integrate cf-deployment as of 73fba59
+2019-10-02 loosely integrate cf-deployment as of 73fba59 (v9.5.0)
+2020-01-20 loosely integrate cf-deployment as of cd8dbd4 (v12.5.0)
+2020-01-22 loosely integrate cf-deployment as of 40d989d (v12.20.0)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -387,6 +387,11 @@ The `haproxy` feature activates a pair of software load balancers,
 running haproxy, that sit in front of the Cloud Foundry gorouter
 layer.
 
+You must specify the IP addressese to be used by the haproxy instances, using
+the `haproxy_ips` parameter in list format.  These IPs must be in the
+range used by the network specified in `cf_lb_network`, which defaults to the
+same network as the `cf_edge_network`
+
 If you also activate the `tls` feature, these haproxy instances
 will terminate your SSL/TLS sessions, and present your
 certificates to connecting clients.

--- a/ci/envs/ci-baseline.yml
+++ b/ci/envs/ci-baseline.yml
@@ -7,6 +7,10 @@ kit:
     - tls
     - self-signed
     - small-footprint
+    - dns-service-discovery
+    - container-routing-integrity
+    - autoscaler
+    - routing-api
 
 params:
   env:   ci-baseline

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,85 @@
+# Major Release Updates
+
+This release brings the releases used by the CF Genesis Kit up to date with
+v12.20.0 of the cf-deployment release.
+
+# Potentially Breaking Changes
+
+* Continuing the remove static IPs theme of 1.7.0, this release drops the
+  static ranges in cloud config for haproxy feature.  Instead, the instances
+  for haproxy instances need to be specified in the `haproxy_ips` parameter in
+  list format.  These ips must be in the range of the `cf_lb_network`, which
+  defaults to the same network that is specified by the `cf_edge_network`
+  parameter.  This removes the requirement for the edge network to be at least
+  a /28.
+
+  If upgrading from versions before 1.7.0, you will need to remove the first
+  10 static IPs from your cloud foundry, as these were used for the go routers
+  and access vms.  The 11th through 15th were reserved for haproxy instances,
+  so in order to not have to change your network addresses, simply use these
+  ips in your `haproxy_ips` list in your environment file and keep them listed
+  as static.
+
+  If upgrading from 1.7.0 and later, same concept applies but will have to
+  take into consideration what you did to remove the other static ips when you
+  upgraded before.
+
+# Improvements
+
+* BBS uses localhost locker to prevent race conditions on cert changes
+* Increased feature coverage for testflight ci process
+* Move smoketests to uaa vm to reduce vm count and test time
+* Added smoketest genesis addon: `genesis do <env> -- smoketest`
+
+# Bug Fixes
+
+* Corrects cert location for dns-service-discovery and haproxy features.  No
+  manual remediation is necessary, as the existing certs will be moved on
+  first check of the environment.
+
+# Core Components
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| bpm | [1.1.6](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.6) | 05 December 2019 |
+| capi | [1.89.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.89.0) | 06 December 2019 |
+| cf-networking | [2.27.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.27.0) | 02 December 2019 |
+| cf-smoke-tests | [40.0.123](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/v40.0.123) | - |
+| cflinuxfs3 | [0.151.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.151.0) | 10 December 2019 |
+| cf-cli | [1.23.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.23.0) | 08 January 2020 |
+| diego | [2.41.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.41.0) | 04 December 2019 |
+| garden-runc | [1.19.9](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.9) | 21 November 2019 |
+| loggregator | [106.3.1](https://github.com/cloudfoundry/loggregator-release/releases/tag/v106.3.1) | 09 December 2019 |
+| loggregator-agent | [5.3.1](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v5.3.1) | 16 December 2019 |
+| log-cache | [2.6.6](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.6.6) | 09 December 2019 |
+| nats | [32](https://github.com/cloudfoundry/nats-release/releases/tag/v32) | - |
+| routing | [0.196.0](https://github.com/cloudfoundry/routing-release/releases/tag/0.196.0) | 05 December 2019 |
+| statsd-injector | [1.11.10](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.11.10) | 16 December 2019 |
+| cf-syslog-drain | [10.2.7](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2.7) | 16 December 2019 |
+| uaa | [74.12.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.12.0) | 03 December 2019 |
+| silk | [2.27.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.27.0) | 02 December 2019 |
+| bosh-dns-aliases | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3) | 24 October 2018 |
+| cflinuxfs2 | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0) | 12 June 2019 |
+| app-autoscaler | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019 |
+| nfs-volume | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0) | 21 August 2019 |
+| mapfs | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0) | 15 July 2019 |
+| postgres | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0) | 19 September 2019 |
+| haproxy | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1) | 05 September 2019 |
+
+
+# Buildpacks
+
+| Release | Version | Release Date |
+| ------- | ------- | ------------ |
+| binary | [1.0.35](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.35) | 10 October 2019 |
+| dotnet-core | [2.3.2](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.3.2) | 05 November 2019 |
+| go | [1.9.3](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.9.3) | 05 November 2019 |
+| java | [4.26](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.26) | 21 November 2019 |
+| nginx | [1.1.1](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.1) | 05 November 2019 |
+| nodejs | [1.7.4](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.7.4) | 22 November 2019 |
+| php | [4.4.2](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.4.2) | 22 November 2019 |
+| python | [1.7.2](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.7.2) | 22 November 2019 |
+| r | [1.1.0](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.1.0) | 22 November 2019 |
+| ruby | [1.8.2](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.8.2) | 05 November 2019 |
+| staticfile | [1.5.1](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.5.1) | 05 November 2019 |
+

--- a/ci/test
+++ b/ci/test
@@ -39,6 +39,6 @@ genesis deploy -y ci-baseline
 $BOSH -d ci-baseline-${KIT} instances --ps
 
 header "Validating BASELINE environment..."
-$BOSH -d ci-baseline-${KIT} run-errand smoke_tests --instance=api/first
+$BOSH -d ci-baseline-${KIT} run-errand smoke_tests --instance=uaa/first
 
 cleanup ci-baseline-${KIT}

--- a/ci/test
+++ b/ci/test
@@ -39,6 +39,6 @@ genesis deploy -y ci-baseline
 $BOSH -d ci-baseline-${KIT} instances --ps
 
 header "Validating BASELINE environment..."
-$BOSH -d ci-baseline-${KIT} run-errand smoke-tests
+$BOSH -d ci-baseline-${KIT} run-errand smoke_tests --instance=api/first
 
 cleanup ci-baseline-${KIT}

--- a/hooks/addon
+++ b/hooks/addon
@@ -22,6 +22,8 @@ list() {
   echo "  asg               Generates application security group definitions,"
   echo "                    in JSON, which can then be fed into Cloud Foundry."
   echo
+  echo "  smoketest         Run the smoke tests errand on the first vm in the"
+  echo "                    api instance group."
 }
 
 
@@ -65,11 +67,11 @@ login)
 
 setup-cli)
   if ! cf list-plugin-repos | grep -q CF-Community; then
-    describe "Adding #G{Cloud Foundry Community} plugins repository..."
+    describe 'Adding #G{Cloud Foundry Community} plugins repository...'
     cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org
   fi
   if ! cf plugins | grep -q '^cf-targets'; then
-    describe "Installing the #C{cf-targets} plugin..."
+    describe 'Installing the #C{cf-targets} plugin...'
     cf install-plugin -r CF-Community Targets
   fi
   cf plugins
@@ -91,7 +93,7 @@ asg)
 bind-autoscaler)
   if [[ $(exodus autoscaler_enabled) != "1" ]]; then
     echo "This Genesis deployment does not have the Autoscaler feature."
-    exit -1
+    exit 1
   fi
   login
   username=$(safe read $vault/autoscaler/servicebroker_account:username)
@@ -108,7 +110,9 @@ bind-autoscaler)
   exit 0
   ;;
 
-
+smoketest)
+  $GENESIS_BOSH_COMMAND -e $BOSH_ENVIRONMENT -d $BOSH_DEPLOYMENT run-errand smoke_tests --instance api/first
+  ;;
 *)
   echo "Unrecognized Cloud Foundry Genesis Kit addon."
   list

--- a/hooks/addon
+++ b/hooks/addon
@@ -111,7 +111,7 @@ bind-autoscaler)
   ;;
 
 smoketest)
-  $GENESIS_BOSH_COMMAND -e $BOSH_ENVIRONMENT -d $BOSH_DEPLOYMENT run-errand smoke_tests --instance api/first
+  $GENESIS_BOSH_COMMAND -e $BOSH_ENVIRONMENT -d $BOSH_DEPLOYMENT run-errand smoke_tests --instance uaa/first
   ;;
 *)
   echo "Unrecognized Cloud Foundry Genesis Kit addon."

--- a/hooks/check
+++ b/hooks/check
@@ -82,21 +82,16 @@ relocate_secret() {
 # Environment Parameter checks
 if want_feature 'tls'; then
 
-  # Check if haproxy certs are in the right location - they moved in v1.9.0 to
-  # conform to the contract of where generated certificates are placed
-  relocate_secret "haproxy/ca"  "haproxy/certs/ca"  || describe "Cannot find HAProxy CA Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
-  relocate_secret "haproxy/ssl" "haproxy/certs/ssl" || describe "Cannot find HAProxy SSL Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
-
   if [[ $env_ok == "yes" ]] ; then
     describe "  checking if our Cloud Foundry certificate matches the system domains..."
     base=$(lookup params.base_domain)
     sys=$(lookup params.system_domain "system.$base")
     for domain in api.$sys login.$sys uaa.$sys something.uaa.$sys; do
-      if safe --quiet x509 validate "$vault/haproxy/certs/ssl" --for "$domain" >/dev/null 2>&1; then
+      if safe --quiet x509 validate "$vault/haproxy/ssl" --for "$domain" >/dev/null 2>&1; then
         describe "    - $domain [#G{OK}]"
       else
         describe "    - $domain [#R{INVALID}]"
-        safe x509 validate "$vault/haproxy/certs/ssl" --for "$domain" 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/haproxy/ssl" --for "$domain" 2>&1 | sed -e 's/^/      /';
         env_ok=no
         echo
       fi
@@ -104,11 +99,11 @@ if want_feature 'tls'; then
 
     describe "  checking if our Cloud Foundry certificate matches the app domains..."
     for domain in $(lookup params.apps_domains "[\"run.$base\"]" | jq -r '.[]'); do
-      if safe --quiet x509 validate "$vault/haproxy/certs/ssl" --for "something.$domain" >/dev/null 2>&1; then
+      if safe --quiet x509 validate "$vault/haproxy/ssl" --for "something.$domain" >/dev/null 2>&1; then
         describe "    - *.$domain [#G{OK}]"
       else
         describe "    - *.$domain [#R{INVALID}]"
-        safe x509 validate "$vault/haproxy/certs/ssl" --for "something.$domain" 2>&1 | sed -e 's/^/      /';
+        safe x509 validate "$vault/haproxy/ssl" --for "something.$domain" 2>&1 | sed -e 's/^/      /';
         env_ok=no
         echo
       fi

--- a/hooks/check
+++ b/hooks/check
@@ -58,29 +58,34 @@ else
   describe "  runtime config [#R{FAILED}]"
 fi
 
-# Environment Parameter checks
 env_ok=yes
+vault="secret/$GENESIS_VAULT_PREFIX"
+secret_exists() {
+  safe --quiet exists "$vault/$1" >/dev/null 2>&1
+}
+relocate_secret() {
+  src="$1"; dst="$2";
+  if ! secret_exists "$dst" ; then
+    if secret_exists "$src" ; then
+      safe --quiet mv "$vault/$src" "$vault/$dst" >/dev/null 2>&1
+    else
+      env_ok=no
+      return 1
+    fi
+  elif secret_exists "$src" ; then
+    # Remove outdated location
+    safe --quiet rm "$vault/$src" >/dev/null 2>&1:
+  fi
+  return 0
+}
+
+# Environment Parameter checks
 if want_feature 'tls'; then
-  vault="secret/$GENESIS_VAULT_PREFIX"
 
   # Check if haproxy certs are in the right location - they moved in v1.9.0 to
   # conform to the contract of where generated certificates are placed
-  if ! safe --quiet exists "$vault/haproxy/certs/ca" >/dev/null 2>&1 ; then
-    if safe --quiet exists "$vault/haproxy/ca" >/dev/null 2>&1 ; then
-      safe --quiet mv "$vault/haproxy/ca"  "$vault/haproxy/certs/ca" >/dev/null 2>&1
-    else
-      describe "Cannot find HAProxy CA Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
-      env_ok=no
-    fi
-  fi
-  if ! safe --quiet exists "$vault/haproxy/certs/ssl" >/dev/null 2>&1 ; then
-    if safe --quiet exists "$vault/haproxy/ssl" >/dev/null 2>&1 ; then
-      safe --quiet mv "$vault/haproxy/ssl"  "$vault/haproxy/certs/ssl" >/dev/null 2>&1
-    elif [[ $env_ok == "yes" ]] ; then
-      describe "Cannot find HAProxy SSL Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
-      env_ok=no
-    fi
-  fi
+  relocate_secret "haproxy/ca"  "haproxy/certs/ca"  || describe "Cannot find HAProxy CA Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
+  relocate_secret "haproxy/ssl" "haproxy/certs/ssl" || describe "Cannot find HAProxy SSL Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
 
   if [[ $env_ok == "yes" ]] ; then
     describe "  checking if our Cloud Foundry certificate matches the system domains..."
@@ -108,32 +113,13 @@ if want_feature 'tls'; then
         echo
       fi
     done
-    fi
+  fi
 fi
 
 # Fix erroneous location of certs for dns-service-discovery introduced in 1.8.0
-if safe --quiet exists "$vault/cf_app_sd/ca" >/dev/null 2>&1 ; then
-  if ! safe --quiet exists "$vault/cf_app_sd/certs/ca" >/dev/null 2>&1 ; then
-    safe --quiet mv "$vault/cf_app_sd/ca"  "$vault/cf_app_sd/certs/ca" >/dev/null 2>&1
-  else
-    safe --quiet rm "$vault/cf_app_sd/ca" >/dev/null 2>&1
-  fi
-fi
-if safe --quiet exists "$vault/cf_app_sd/client" >/dev/null 2>&1 ; then
-  if ! safe --quiet exists "$vault/cf_app_sd/certs/client" >/dev/null 2>&1 ; then
-    safe --quiet mv "$vault/cf_app_sd/client"  "$vault/cf_app_sd/certs/client" >/dev/null 2>&1
-  else
-    safe --quiet rm "$vault/cf_app_sd/server" >/dev/null 2>&1
-  fi
-fi
-if safe --quiet exists "$vault/cf_app_sd/server" >/dev/null 2>&1 ; then
-  if ! safe --quiet exists "$vault/cf_app_sd/certs/server" >/dev/null 2>&1 ; then
-    safe --quiet mv "$vault/cf_app_sd/server"  "$vault/cf_app_sd/certs/server" >/dev/null 2>&1
-  else
-    safe --quiet rm "$vault/cf_app_sd/server" >/dev/null 2>&1
-  fi
-fi
-
+relocate_secret "cf_app_sd/ca"     "cf_app_sd/certs/ca"
+relocate_secret "cf_app_sd/client" "cf_app_sd/certs/client"
+relocate_secret "cf_app_sd/server" "cf_app_sd/certs/server"
 
 if [[ "$env_ok" == "yes" ]]; then
   describe "  environment files [#G{OK}]"

--- a/hooks/check
+++ b/hooks/check
@@ -63,32 +63,77 @@ env_ok=yes
 if want_feature 'tls'; then
   vault="secret/$GENESIS_VAULT_PREFIX"
 
-  describe "  checking if our Cloud Foundry certificate matches the system domains..."
-  base=$(lookup params.base_domain)
-  sys=$(lookup params.system_domain "system.$base")
-  for domain in api.$sys login.$sys uaa.$sys something.uaa.$sys; do
-    if safe --quiet x509 validate "$vault/haproxy/ssl" --for "$domain" >/dev/null 2>&1; then
-      describe "    - $domain [#G{OK}]"
+  # Check if haproxy certs are in the right location - they moved in v1.9.0 to
+  # conform to the contract of where generated certificates are placed
+  if ! safe --quiet exists "$vault/haproxy/certs/ca" >/dev/null 2>&1 ; then
+    if safe --quiet exists "$vault/haproxy/ca" >/dev/null 2>&1 ; then
+      safe --quiet mv "$vault/haproxy/ca"  "$vault/haproxy/certs/ca" >/dev/null 2>&1
     else
-      describe "    - $domain [#R{INVALID}]"
-      safe x509 validate "$vault/haproxy/ssl" --for "$domain" 2>&1 | sed -e 's/^/      /';
+      describe "Cannot find HAProxy CA Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
       env_ok=no
-      echo
     fi
-  done
+  fi
+  if ! safe --quiet exists "$vault/haproxy/certs/ssl" >/dev/null 2>&1 ; then
+    if safe --quiet exists "$vault/haproxy/ssl" >/dev/null 2>&1 ; then
+      safe --quiet mv "$vault/haproxy/ssl"  "$vault/haproxy/certs/ssl" >/dev/null 2>&1
+    elif [[ $env_ok == "yes" ]] ; then
+      describe "Cannot find HAProxy SSL Certificates - please run \`genesis add-secrets $GENESIS_ENVIRONMENT\`"
+      env_ok=no
+    fi
+  fi
 
-  describe "  checking if our Cloud Foundry certificate matches the app domains..."
-  for domain in $(lookup params.apps_domains "[\"run.$base\"]" | jq -r '.[]'); do
-    if safe --quiet x509 validate "$vault/haproxy/ssl" --for "something.$domain" >/dev/null 2>&1; then
-      describe "    - *.$domain [#G{OK}]"
-    else
-      describe "    - *.$domain [#R{INVALID}]"
-      safe x509 validate "$vault/haproxy/ssl" --for "something.$domain" 2>&1 | sed -e 's/^/      /';
-      env_ok=no
-      echo
+  if [[ $env_ok == "yes" ]] ; then
+    describe "  checking if our Cloud Foundry certificate matches the system domains..."
+    base=$(lookup params.base_domain)
+    sys=$(lookup params.system_domain "system.$base")
+    for domain in api.$sys login.$sys uaa.$sys something.uaa.$sys; do
+      if safe --quiet x509 validate "$vault/haproxy/certs/ssl" --for "$domain" >/dev/null 2>&1; then
+        describe "    - $domain [#G{OK}]"
+      else
+        describe "    - $domain [#R{INVALID}]"
+        safe x509 validate "$vault/haproxy/certs/ssl" --for "$domain" 2>&1 | sed -e 's/^/      /';
+        env_ok=no
+        echo
+      fi
+    done
+
+    describe "  checking if our Cloud Foundry certificate matches the app domains..."
+    for domain in $(lookup params.apps_domains "[\"run.$base\"]" | jq -r '.[]'); do
+      if safe --quiet x509 validate "$vault/haproxy/certs/ssl" --for "something.$domain" >/dev/null 2>&1; then
+        describe "    - *.$domain [#G{OK}]"
+      else
+        describe "    - *.$domain [#R{INVALID}]"
+        safe x509 validate "$vault/haproxy/certs/ssl" --for "something.$domain" 2>&1 | sed -e 's/^/      /';
+        env_ok=no
+        echo
+      fi
+    done
     fi
-  done
 fi
+
+# Fix erroneous location of certs for dns-service-discovery introduced in 1.8.0
+if safe --quiet exists "$vault/cf_app_sd/ca" >/dev/null 2>&1 ; then
+  if ! safe --quiet exists "$vault/cf_app_sd/certs/ca" >/dev/null 2>&1 ; then
+    safe --quiet mv "$vault/cf_app_sd/ca"  "$vault/cf_app_sd/certs/ca" >/dev/null 2>&1
+  else
+    safe --quiet rm "$vault/cf_app_sd/ca" >/dev/null 2>&1
+  fi
+fi
+if safe --quiet exists "$vault/cf_app_sd/client" >/dev/null 2>&1 ; then
+  if ! safe --quiet exists "$vault/cf_app_sd/certs/client" >/dev/null 2>&1 ; then
+    safe --quiet mv "$vault/cf_app_sd/client"  "$vault/cf_app_sd/certs/client" >/dev/null 2>&1
+  else
+    safe --quiet rm "$vault/cf_app_sd/server" >/dev/null 2>&1
+  fi
+fi
+if safe --quiet exists "$vault/cf_app_sd/server" >/dev/null 2>&1 ; then
+  if ! safe --quiet exists "$vault/cf_app_sd/certs/server" >/dev/null 2>&1 ; then
+    safe --quiet mv "$vault/cf_app_sd/server"  "$vault/cf_app_sd/certs/server" >/dev/null 2>&1
+  else
+    safe --quiet rm "$vault/cf_app_sd/server" >/dev/null 2>&1
+  fi
+fi
+
 
 if [[ "$env_ok" == "yes" ]]; then
   describe "  environment files [#G{OK}]"

--- a/kit.yml
+++ b/kit.yml
@@ -89,7 +89,8 @@ certificates:
       diego_locket_server: #was diego/certs/bbs
         valid_for: 1y
         names:     [ "locket.service.cf.internal",
-                     "*.locket.service.cf.internal" ]
+                     "*.locket.service.cf.internal",
+                     "127.0.0.1" ]
         usage:     [ server_auth ]
 
       diego_rep_client: #was diego/certs/rep_client

--- a/kit.yml
+++ b/kit.yml
@@ -299,7 +299,7 @@ certificates:
         names:     [ "uaa.service.cf.internal" ]
 
   dns-service-discovery:
-    cf_app_sd: # was service-disco
+    cf_app_sd/certs: # was service-disco
       ca:
         valid_for: 1y
         names:     [ "service-discovery-controller.service.cf.internal" ]
@@ -313,7 +313,7 @@ certificates:
         usage:     [ client_auth ]
 
   self-signed:
-    haproxy:
+    haproxy/certs:
       ca:
         valid_for: 1y
         names:     [ "haProxyCA" ]

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -201,15 +201,6 @@ instance_groups:
     migrated_from:
       - name: diego-cell
 
-  - name: smoke-tests
-    instances: 1
-    vm_type: (( grab params.errand_vm_type ))
-    azs: (( grab params.availability_zones || meta.default.azs ))
-    stemcell: default
-    networks:
-      - name: (( grab params.cf_internal_network ))
-    lifecycle: errand
-
 update:
   canaries: 1
   max_in_flight: 50

--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -198,6 +198,8 @@ instance_groups:
     update:
       serial: true
       max_in_flight: 1
+      canary_watch_time: 30000-240000
+      update_watch_time: 30000-240000
     migrated_from:
       - name: diego-cell
 

--- a/manifests/cf/bbs.yml
+++ b/manifests/cf/bbs.yml
@@ -33,6 +33,8 @@ instance_groups:
                 client_key:  (( grab meta.certs.cf_internal.diego_auctioneer_client.key ))
                 require_tls: true
               rep: (( grab meta.diego_rep_client_tls ))
+              locket:
+                api_location: 127.0.0.1:8891
               sql:
                 #no ssl to the sql backend
                 require_ssl: false

--- a/manifests/cf/releases.yml
+++ b/manifests/cf/releases.yml
@@ -1,13 +1,13 @@
 releases:
   - name:    bpm
-    version: "1.1.5"
+    version: "1.1.6"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=" releases.bpm.version ))
-    sha1:    e612e88543012ae5d376dd3746159d5abe748076
+    sha1:    5bad6161dbbcf068830a100b6a76056fe3b99bc8
 
   - name:    capi
-    version: "1.88.0"
+    version: "1.89.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=" releases.capi.version ))
-    sha1:    7a7ef183de3252724b6f8e6ca39ad7cf4995fe27
+    sha1:    472966da017bda3118eb9cf71f9bcca1c23c344a
 
   - name:    cf-networking
     version: "2.27.0"
@@ -20,14 +20,14 @@ releases:
     sha1:    aeea22d0d7003d69b1d6154bae41360f821be420
 
   - name:    cflinuxfs3
-    version: "0.150.0"
+    version: "0.151.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=" releases.cflinuxfs3.version ))
-    sha1:    6421766b2120009c6d422c4b1ed5a12c4290eda4
+    sha1:    69dadce013b1be20356980e5f4d4736c50c3de31
 
   - name:    cf-cli
-    version: "1.22.0"
+    version: "1.23.0"
     url:     (( concat "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=" releases.cf-cli.version ))
-    sha1:    ccdd798cc523f64037e01e0a888a206ceb018536
+    sha1:    cda431fa1e550c28bf6f5c82b3a3cf2c168771f2
 
   - name:    diego
     version: "2.41.0"
@@ -40,39 +40,39 @@ releases:
     sha1:    1c678e1c7a3506c0e408860571560081c15e3c6d
 
   - name:    loggregator
-    version: "106.2.1"
+    version: "106.3.1"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=" releases.loggregator.version ))
-    sha1:    b0758449cb7bf683d88375e5b3f230c70ce4d6ec
+    sha1:    050d3ec33126c16093bb60a088f62dd51f5083cb
 
   - name:    loggregator-agent
-    version: "5.2.2"
+    version: "5.3.1"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=" releases.loggregator-agent.version ))
-    sha1:    da2da3417936921a692bda4fa5390cb113e137dd
+    sha1:    f7133189f2d1389d40d7c454ddd820a63c3d7cb1
 
   - name:    log-cache
-    version: "2.6.1"
+    version: "2.6.6"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=" releases.log-cache.version ))
-    sha1:    a8b057ce9a942788dfbb356904e5a793954c6411
+    sha1:    ed9c200fdedfa1118d80f895f4e91dedca3f0f5d
 
   - name:    nats
-    version: "28"
+    version: "32"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nats-release?v=" releases.nats.version ))
-    sha1:    64b143778b4cd741970798e32523d564d429d62a
+    sha1:    9cc4979e2d1e7452f8e2b90c6f52d473b080596b
 
   - name:    routing
-    version: "0.195.0"
+    version: "0.196.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=" releases.routing.version ))
-    sha1:    2b899d7bd6d35b9aacb410f0343989e82397d86d
+    sha1:    5eab0c9c35b4f047ff83d0a266223edb357cb02d
 
   - name:    statsd-injector
-    version: "1.11.4"
+    version: "1.11.10"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=" releases.statsd-injector.version ))
-    sha1:    255e718ed424a8e3d6ccfe8a4c5c5c0718fced17
+    sha1:    08e212487c5f4eb1309ab05c849ff7f1e8ece26f
 
   - name:    cf-syslog-drain
-    version: "10.2.2"
+    version: "10.2.7"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=" releases.cf-syslog-drain.version ))
-    sha1:    e899847cd564cb53232961cc1621e3bbec1189e1
+    sha1:    3bd11827c614fc14fb187625e002312ff6c2666d
 
   - name:    uaa
     version: "74.12.0"

--- a/manifests/cf/smoke-tests.yml
+++ b/manifests/cf/smoke-tests.yml
@@ -1,6 +1,6 @@
 ---
 instance_groups:
-  - name: api
+  - name: uaa
     jobs:
       - name: smoke_tests
         release: cf-smoke-tests

--- a/manifests/cf/smoke-tests.yml
+++ b/manifests/cf/smoke-tests.yml
@@ -1,6 +1,6 @@
 ---
 instance_groups:
-  - name: smoke-tests
+  - name: api
     jobs:
       - name: smoke_tests
         release: cf-smoke-tests

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -213,7 +213,7 @@ instance_groups:
 
                 health_check:
                   name: uaa-healthcheck
-                  script_path: /var/vcap/jobs/uaa/bin/health_check
+                  script_path: /var/vcap/jobs/uaa/bin/dns/healthy
 
                 uris:
                   - (( concat "uaa." params.system_domain ))

--- a/manifests/routing/haproxy-tls.yml
+++ b/manifests/routing/haproxy-tls.yml
@@ -12,4 +12,4 @@ instance_groups:
             disable_tls_10: (( grab params.disable_tls_10 ))
             disable_tls_11: (( grab params.disable_tls_11 ))
 
-            ssl_pem: (( vault meta.vault "/haproxy/certs/ssl:combined" ))
+            ssl_pem: (( vault meta.vault "/haproxy/ssl:combined" ))

--- a/manifests/routing/haproxy-tls.yml
+++ b/manifests/routing/haproxy-tls.yml
@@ -12,4 +12,4 @@ instance_groups:
             disable_tls_10: (( grab params.disable_tls_10 ))
             disable_tls_11: (( grab params.disable_tls_11 ))
 
-            ssl_pem: (( vault meta.vault "/haproxy/ssl:combined" ))
+            ssl_pem: (( vault meta.vault "/haproxy/certs/ssl:combined" ))

--- a/manifests/routing/haproxy.yml
+++ b/manifests/routing/haproxy.yml
@@ -3,10 +3,11 @@ params:
   internal_only_domains: []
   trusted_domain_cidrs: ~
 
+  cf_lb_network: (( grab params.cf_edge_network ))
+
   haproxy_instances: 2
   haproxy_vm_type:   haproxy
-
-  haproxy_ips: (( param "Please specify the IP addresses for your load balancer instances" ))
+  haproxy_ips:       (( param "Please specify the IP addresses for your load balancer instances" ))
 
 instance_groups:
   - name: router
@@ -20,7 +21,7 @@ instance_groups:
 
     stemcell: default
     networks:
-      - name: (( grab params.cf_edge_network ))
+      - name:       (( grab params.cf_lb_network ))
         static_ips: (( grab params.haproxy_ips ))
 
     vm_extensions:


### PR DESCRIPTION
# Major Release Updates

This release brings the releases used by the CF Genesis Kit up to date with
v12.20.0 of the cf-deployment release.

# Potentially Breaking Changes

* Continuing the remove static IPs theme of 1.7.0, this release drops the
  static ranges in cloud config for haproxy feature.  Instead, the instances
  for haproxy instances need to be specified in the `haproxy_ips` parameter in
  list format.  These ips must be in the range of the `cf_lb_network`, which
  defaults to the same network that is specified by the `cf_edge_network`
  parameter.  This removes the requirement for the edge network to be at least
  a /28.

  If upgrading from versions before 1.7.0, you will need to remove the first
  10 static IPs from your cloud foundry, as these were used for the go routers
  and access vms.  The 11th through 15th were reserved for haproxy instances,
  so in order to not have to change your network addresses, simply use these
  ips in your `haproxy_ips` list in your environment file and keep them listed
  as static.

  If upgrading from 1.7.0 and later, same concept applies but will have to
  take into consideration what you did to remove the other static ips when you
  upgraded before.

# Improvements

* BBS uses localhost locker to prevent race conditions on cert changes
* Increased feature coverage for testflight ci process
* Move smoketests to uaa vm to reduce vm count and test time
* Added smoketest genesis addon: `genesis do <env> -- smoketest`

# Bug Fixes

* Corrects cert location for dns-service-discovery and haproxy features.  No
  manual remediation is necessary, as the existing certs will be moved on
  first check of the environment.

# Core Components

| Release | Version | Release Date |
| ------- | ------- | ------------ |
| bpm | [1.1.6](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.6) | 05 December 2019 |
| capi | [1.89.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.89.0) | 06 December 2019 |
| cf-networking | [2.27.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.27.0) | 02 December 2019 |
| cf-smoke-tests | [40.0.123](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/v40.0.123) | - |
| cflinuxfs3 | [0.151.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.151.0) | 10 December 2019 |
| cf-cli | [1.23.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.23.0) | 08 January 2020 |
| diego | [2.41.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.41.0) | 04 December 2019 |
| garden-runc | [1.19.9](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.9) | 21 November 2019 |
| loggregator | [106.3.1](https://github.com/cloudfoundry/loggregator-release/releases/tag/v106.3.1) | 09 December 2019 |
| loggregator-agent | [5.3.1](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v5.3.1) | 16 December 2019 |
| log-cache | [2.6.6](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.6.6) | 09 December 2019 |
| nats | [32](https://github.com/cloudfoundry/nats-release/releases/tag/v32) | - |
| routing | [0.196.0](https://github.com/cloudfoundry/routing-release/releases/tag/0.196.0) | 05 December 2019 |
| statsd-injector | [1.11.10](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.11.10) | 16 December 2019 |
| cf-syslog-drain | [10.2.7](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2.7) | 16 December 2019 |
| uaa | [74.12.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.12.0) | 03 December 2019 |
| silk | [2.27.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.27.0) | 02 December 2019 |
| bosh-dns-aliases | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3) | 24 October 2018 |
| cflinuxfs2 | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0) | 12 June 2019 |
| app-autoscaler | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019 |
| nfs-volume | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0) | 21 August 2019 |
| mapfs | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0) | 15 July 2019 |
| postgres | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0) | 19 September 2019 |
| haproxy | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1) | 05 September 2019 |


# Buildpacks

| Release | Version | Release Date |
| ------- | ------- | ------------ |
| binary | [1.0.35](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.35) | 10 October 2019 |
| dotnet-core | [2.3.2](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.3.2) | 05 November 2019 |
| go | [1.9.3](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.9.3) | 05 November 2019 |
| java | [4.26](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.26) | 21 November 2019 |
| nginx | [1.1.1](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.1) | 05 November 2019 |
| nodejs | [1.7.4](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.7.4) | 22 November 2019 |
| php | [4.4.2](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.4.2) | 22 November 2019 |
| python | [1.7.2](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.7.2) | 22 November 2019 |
| r | [1.1.0](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.1.0) | 22 November 2019 |
| ruby | [1.8.2](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.8.2) | 05 November 2019 |
| staticfile | [1.5.1](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.5.1) | 05 November 2019 |
