### PR TITLE
1.9.1 rc

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+# Bug Fixes
+
+* v1.9.0 required locket server TLS certificate to be valid for 127.0.0.1.
+  This release fixes this problem by automatically regenerating that secret if
+  this is not the case. (Issue #108)
+
+* v1.9.0 fixed an issue where the certificates for the `dns-service-discovery`
+  feature were placed incorrectly in v1.8.0, but the method to resolve this
+  caused an error if these certificates were not present. (#107)

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -267,6 +267,14 @@ if [[ $database -gt 1 ]]; then
   echo >&2 "You have enabled more than one Database feature flag."
   exit 1
 fi
+# An in-situ upgrade of CF required $GENESIS_VAULT_PREFIX/locket/certs/server to include 127.0.0.1
+# as a SAN. Rather than bothering the operator for an internal cert with no impact on external
+# performance, it's better to just delete and regen the cert automatically.
+if safe exists "$vault/locket/certs/server" >/dev/null 2>&1 && ! safe --quiet x509 validate "$vault/locket/certs/server" --for "127.0.0.1" >/dev/null 2>&1; then
+  echo >&2 "  performing one-time update of Locket Server certificate"
+  safe rm "$vault/locket/certs/server" >/dev/null 2>&1
+  genesis -C $GENESIS_ROOT add-secrets $GENESIS_ENVIRONMENT >/dev/null 2>&1
+fi
 
 # An in-situ fix to ensure the diego_instance_identity_ca is signed by the appRootCA
 vault="secret/$GENESIS_VAULT_PREFIX"

--- a/hooks/check
+++ b/hooks/check
@@ -69,7 +69,6 @@ relocate_secret() {
     if secret_exists "$src" ; then
       safe --quiet mv "$vault/$src" "$vault/$dst" >/dev/null 2>&1
     else
-      env_ok=no
       return 1
     fi
   elif secret_exists "$src" ; then


### PR DESCRIPTION
# Bug Fixes

* v1.9.0 required locket server TLS certificate to be valid for 127.0.0.1.
  This release fixes this problem by automatically regenerating that secret if
  this is not the case. (Issue #108)

* v1.9.0 fixed an issue where the certificates for the `dns-service-discovery`
  feature were placed incorrectly in v1.8.0, but the method to resolve this
  caused an error if these certificates were not present. (#107)
