### PR TITLE
1.10.0 RC

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,62 @@
+# Major Release
+
+* This release brings `cf-genesis-kit` up to date with the releases found in
+  `cf-deployment` v12.25.0.
+
+# New Features
+
+* Log Throttling: by specifying `params.max_log_lines_per_second`, you can
+  limit the maximum log lines per second per app instance.  A value of 0
+  disables this limit (which is the default state).
+
+  Note: This is an _EXPERIMENTAL_ feature, and as such, should not be used in
+  a production environment without full understanding of its implications.
+  See the associated [Pivotal Tracker story](https://www.pivotaltracker.com/n/projects/1003146/stories/170087515)
+
+# Core Components
+
+| Release           | Version                                                                                       | Release Date      |
+| ----------------- | --------------------------------------------------------------------------------------------- | ----------------- |
+| bpm               | [1.1.6](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.6)                      | 05 December 2019  |
+| capi              | [1.89.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.89.0)                    | 06 December 2019  |
+| cf-networking     | [2.27.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.27.0)           | 02 December 2019  |
+|*cf-smoke-tests*   | [40.0.125](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/40.0.125)      | 03 January 2020   |
+|*cflinuxfs3*       | [0.154.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.154.0)           | 14 January 2020   |
+|*cf-cli*           | [1.24.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.24.0)                | 08 January 2020   |
+|*diego*            | [2.42.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.42.0)                  | 14 January 2020   |
+| garden-runc       | [1.19.9](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.9)            | 21 November 2019  |
+|*loggregator*      | [106.3.5](https://github.com/cloudfoundry/loggregator-release/releases/tag/v106.3.5)          | 13 January 2020   |
+|*loggregator-agent*| [5.3.4](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v5.3.4)        | 13 January 2020   |
+|*log-cache*        | [2.6.8](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.6.8)                | 30 December 2019  |
+| nats              | [32](https://github.com/cloudfoundry/nats-release/releases/tag/v32)                           | 11 December 2019  |
+| routing           | [0.196.0](https://github.com/cloudfoundry/routing-release/releases/tag/0.196.0)               | 05 December 2019  |
+|*statsd-injector*  | [1.11.13](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.11.13)      | 13 January 2020   |
+|*cf-syslog-drain*  | [10.2.9](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2.9)        | 13 January 2020   |
+|*uaa*              | [74.13.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.13.0)                  | 13 January 2020   |
+| silk              | [2.27.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.27.0)                    | 02 December 2019  |
+| bosh-dns-aliases  | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3)         | 24 October 2018   |
+| cflinuxfs2        | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0)           | 12 June 2019      |
+| app-autoscaler    | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019    |
+| nfs-volume        | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0)               | 21 August 2019    |
+| mapfs             | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0)                    | 15 July 2019      |
+| postgres          | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0)   | 19 September 2019 |
+| haproxy           | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1)    | 05 September 2019 |
+
+
+# Buildpacks
+
+| Release     | Version                                                                                   | Release Date     |
+| ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
+|*binary*     | [1.0.36](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.36)    | 08 January 2020  |
+|*dotnet-core*| [2.3.3](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.3.3) | 08 January 2020  |
+|*go*         | [1.9.4](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.9.4)          | 08 January 2020  |
+| java        | [4.26](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.26)          | 21 November 2019 |
+|_nginx_      | [1.1.3](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.3)       | 08 January 2020  |
+|*nodejs*     | [1.7.8](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.7.8)      | 08 January 2020  |
+|*php*        | [4.4.5](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.4.5)         | 08 January 2020  |
+|*python*     | [1.7.5](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.7.5)      | 08 January 2020  |
+|*r*          | [1.1.1](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.1.1)           | 08 January 2020  |
+|*ruby*       | [1.8.6](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.8.6)        | 08 January 2020  |
+|*staticfile* | [1.5.3](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.5.3)  | 08 January 2020  |
+
+Note: Core Component and Buildpack releases in *italics* were updated as part of this kit release.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -51,7 +51,7 @@
 |*dotnet-core*| [2.3.3](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.3.3) | 08 January 2020  |
 |*go*         | [1.9.4](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.9.4)          | 08 January 2020  |
 | java        | [4.26](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.26)          | 21 November 2019 |
-|_nginx_      | [1.1.3](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.3)       | 08 January 2020  |
+|*nginx*      | [1.1.3](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.3)       | 08 January 2020  |
 |*nodejs*     | [1.7.8](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.7.8)      | 08 January 2020  |
 |*php*        | [4.4.5](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.4.5)         | 08 January 2020  |
 |*python*     | [1.7.5](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.7.5)      | 08 January 2020  |

--- a/dev/update
+++ b/dev/update
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+upstream_releases=$(spruce json ../cf-deployment/cf-deployment.yml)
+releases=$(spruce json manifests/cf/releases.yml)
+buildpacks=$(spruce json manifests/cf/buildpacks.yml)
+
+get() {
+      echo ${upstream_releases} \
+      | jq -r --arg name ${1} --arg field ${2} '.releases | map(select(.name == $name))[0][$field]'
+
+}
+
+echo "releases:" > manifests/cf/releases.yml
+for name in $(echo ${releases} | jq -r '.releases[].name'); do
+  url=$(get ${name} url | cut -d= -f1)
+  echo -e "  - name:    ${name}
+    version: \"$(get ${name} version)\"
+    url:     (( concat \"${url}=\" releases.${name}.version ))
+    sha1:    $(get ${name} sha1)\n"
+done >> manifests/cf/releases.yml
+
+
+echo "releases:" > manifests/cf/buildpacks.yml
+for name in $(echo ${buildpacks} | jq -r '.releases[].name'); do
+  url=$(get ${name} url | cut -d= -f1)
+  echo -e "  - name:    ${name}
+    version: \"$(get ${name} version)\"
+    url:     (( concat \"${url}=\" releases.${name}.version ))
+    sha1:    $(get ${name} sha1)\n"
+done >> manifests/cf/buildpacks.yml

--- a/devtools/update-releases-from-cf-deployment
+++ b/devtools/update-releases-from-cf-deployment
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Assumes you have cf-deployment repo checked out and located as a peer to this
+# repo
+if [[ -f ../cf-deployment/cf-deployment.yml ]] ; then
+  echo "Missing cf-deployment repo in parent directory"
+  exit 1
+fi
+
 upstream_releases=$(spruce json ../cf-deployment/cf-deployment.yml)
 releases=$(spruce json manifests/cf/releases.yml)
 buildpacks=$(spruce json manifests/cf/buildpacks.yml)

--- a/manifests/cf/buildpacks.yml
+++ b/manifests/cf/buildpacks.yml
@@ -1,18 +1,18 @@
 releases:
   - name:    binary-buildpack
-    version: "1.0.35"
+    version: "1.0.36"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=" releases.binary-buildpack.version ))
-    sha1:    d735bedac8a9c7346b4c0f41edeabc779223928c
+    sha1:    0269a613be68f988682bbf56504b78477965b1c4
 
   - name:    dotnet-core-buildpack
-    version: "2.3.2"
+    version: "2.3.3"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=" releases.dotnet-core-buildpack.version ))
-    sha1:    82baada4dc48cb499abb49ca5aff91e59e7e7b48
+    sha1:    51ca401e07b5d7b5c0753af169930c6c0a68b731
 
   - name:    go-buildpack
-    version: "1.9.3"
+    version: "1.9.4"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=" releases.go-buildpack.version ))
-    sha1:    0c86b47463b72709d0c070308ddf691d29f45f55
+    sha1:    5c7a46f9fcf71a0cc7aab460269f6e54cfc51fd9
 
   - name:    java-buildpack
     version: "4.26"
@@ -20,36 +20,37 @@ releases:
     sha1:    24e8c51cbf364fc38f40d0e261dd3bb663e145e3
 
   - name:    nginx-buildpack
-    version: "1.1.1"
+    version: "1.1.3"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=" releases.nginx-buildpack.version ))
-    sha1:    7730085576fbccf84e8a01b3180e2e021151449d
+    sha1:    afe94181ae98b737331e015246f4e5ea3a991d8e
 
   - name:    nodejs-buildpack
-    version: "1.7.4"
+    version: "1.7.8"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=" releases.nodejs-buildpack.version ))
-    sha1:    31635640d0e52b899386dbcd3911c8c92b92f112
+    sha1:    5150b184ddeb36532d48a9caa9889b6a89a55636
 
   - name:    php-buildpack
-    version: "4.4.2"
+    version: "4.4.5"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=" releases.php-buildpack.version ))
-    sha1:    90c5eff395300cef53a2817aede7ef869e06853c
+    sha1:    31e2bba32906d4e6ae8081a69c5922e3979ac682
 
   - name:    python-buildpack
-    version: "1.7.2"
+    version: "1.7.5"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=" releases.python-buildpack.version ))
-    sha1:    be453857ec5e054f41539eda19bdc28d458583a4
+    sha1:    a48bdaa36bfe8f73c8a31d6d81608df7b3706c75
 
   - name:    r-buildpack
-    version: "1.1.0"
+    version: "1.1.1"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=" releases.r-buildpack.version ))
-    sha1:    786f2407c86666d0ace54bf3040b5c6558a61b4f
+    sha1:    eb406b09e0cafb176c8ab52752da41e736b81cea
 
   - name:    ruby-buildpack
-    version: "1.8.2"
+    version: "1.8.6"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=" releases.ruby-buildpack.version ))
-    sha1:    af14339b39d0d22db2fe2fc7c3abde57eb2b59e5
+    sha1:    0c0dd929dbc454e1b2d07dcb662e5623082bc689
 
   - name:    staticfile-buildpack
-    version: "1.5.1"
+    version: "1.5.3"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=" releases.staticfile-buildpack.version ))
-    sha1:    3e73d59a9e0210a36ca2ac8db74a9a263b85fbb4
+    sha1:    950427d4f8556d26ccc457fd8dabbeb93d14a16c
+

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -9,6 +9,7 @@ meta:
 params:
   trusted_cas: []
   evacuation_timeout: 600
+  max_log_lines_per_second: 0 # 0=disabled minimum recommended: 100
 
 instance_groups:
   - name: cell
@@ -44,6 +45,7 @@ instance_groups:
           executor:
             instance_identity_ca_cert: (( grab meta.certs.diego_instance_identity_ca.cert )) # this seems weird
             instance_identity_key:     (( grab meta.certs.diego_instance_identity_ca.key ))
+            max_log_lines_per_second:  (( grab params.max_log_lines_per_second ))
           rep:
             evacuation_timeout_in_seconds: (( grab params.evacuation_timeout ))
             listen_addr_admin: ~

--- a/manifests/cf/releases.yml
+++ b/manifests/cf/releases.yml
@@ -15,24 +15,24 @@ releases:
     sha1:    1249e8140449126a9eb6102218c89eb1196c649e
 
   - name:    cf-smoke-tests
-    version: "40.0.123"
+    version: "40.0.125"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=" releases.cf-smoke-tests.version ))
-    sha1:    aeea22d0d7003d69b1d6154bae41360f821be420
+    sha1:    9d1823d9276aba11261ca59e04e96655e418681b
 
   - name:    cflinuxfs3
-    version: "0.151.0"
+    version: "0.154.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=" releases.cflinuxfs3.version ))
-    sha1:    69dadce013b1be20356980e5f4d4736c50c3de31
+    sha1:    ca95b338896f52e8df54c69e7353894ba635c9fd
 
   - name:    cf-cli
-    version: "1.23.0"
+    version: "1.24.0"
     url:     (( concat "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=" releases.cf-cli.version ))
-    sha1:    cda431fa1e550c28bf6f5c82b3a3cf2c168771f2
+    sha1:    2abe6917b9f576a700418522f1bf452af5768819
 
   - name:    diego
-    version: "2.41.0"
+    version: "2.42.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/diego-release?v=" releases.diego.version ))
-    sha1:    8a183683f26ba982eda1dbeba7f55edc9a1059b0
+    sha1:    d92d29385f7b1020d95cdcd12d97e378773d1168
 
   - name:    garden-runc
     version: "1.19.9"
@@ -40,19 +40,19 @@ releases:
     sha1:    1c678e1c7a3506c0e408860571560081c15e3c6d
 
   - name:    loggregator
-    version: "106.3.1"
+    version: "106.3.5"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=" releases.loggregator.version ))
-    sha1:    050d3ec33126c16093bb60a088f62dd51f5083cb
+    sha1:    d7f5203522753ed9cc12e4c0b5714264d7c37c41
 
   - name:    loggregator-agent
-    version: "5.3.1"
+    version: "5.3.4"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=" releases.loggregator-agent.version ))
-    sha1:    f7133189f2d1389d40d7c454ddd820a63c3d7cb1
+    sha1:    d62dd7a540210727ac503cc3856722b78184080b
 
   - name:    log-cache
-    version: "2.6.6"
+    version: "2.6.8"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=" releases.log-cache.version ))
-    sha1:    ed9c200fdedfa1118d80f895f4e91dedca3f0f5d
+    sha1:    3a5bcd3162387cd2fd2deb6e15a29bfff398cdae
 
   - name:    nats
     version: "32"
@@ -65,19 +65,19 @@ releases:
     sha1:    5eab0c9c35b4f047ff83d0a266223edb357cb02d
 
   - name:    statsd-injector
-    version: "1.11.10"
+    version: "1.11.13"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=" releases.statsd-injector.version ))
-    sha1:    08e212487c5f4eb1309ab05c849ff7f1e8ece26f
+    sha1:    b780e2269e28b62d2306c14fa1c97b914dad7387
 
   - name:    cf-syslog-drain
-    version: "10.2.7"
+    version: "10.2.9"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=" releases.cf-syslog-drain.version ))
-    sha1:    3bd11827c614fc14fb187625e002312ff6c2666d
+    sha1:    98a18dcff81a983c95b8ce5c0a41b5627f4314ac
 
   - name:    uaa
-    version: "74.12.0"
+    version: "74.13.0"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=" releases.uaa.version ))
-    sha1:    5fdd99addec2aebe521a468dba0bcd52e66c86c6
+    sha1:    2eef558edc434d240d43ae255b59b10754d4785e
 
   - name:    silk
     version: "2.27.0"
@@ -88,3 +88,4 @@ releases:
     version: "0.0.3"
     url:     (( concat "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=" releases.bosh-dns-aliases.version ))
     sha1:    b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
+


### PR DESCRIPTION
# Major Release

* This release brings `cf-genesis-kit` up to date with the releases found in
  `cf-deployment` v12.25.0.

# New Features

* Log Throttling: by specifying `params.max_log_lines_per_second`, you can
  limit the maximum log lines per second per app instance.  A value of 0
  disables this limit (which is the default state).

  Note: This is an _EXPERIMENTAL_ feature, and as such, should not be used in
  a production environment without full understanding of its implications.
  See the associated [Pivotal Tracker story](https://www.pivotaltracker.com/n/projects/1003146/stories/170087515)

# Core Components

| Release           | Version                                                                                       | Release Date      |
| ----------------- | --------------------------------------------------------------------------------------------- | ----------------- |
| bpm               | [1.1.6](https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.6)                      | 05 December 2019  |
| capi              | [1.89.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.89.0)                    | 06 December 2019  |
| cf-networking     | [2.27.0](https://github.com/cloudfoundry/cf-networking-release/releases/tag/2.27.0)           | 02 December 2019  |
|*cf-smoke-tests*   | [40.0.125](https://github.com/cloudfoundry/cf-smoke-tests-release/releases/tag/40.0.125)      | 03 January 2020   |
|*cflinuxfs3*       | [0.154.0](https://github.com/cloudfoundry/cflinuxfs3-release/releases/tag/v0.154.0)           | 14 January 2020   |
|*cf-cli*           | [1.24.0](https://github.com/bosh-packages/cf-cli-release/releases/tag/v1.24.0)                | 08 January 2020   |
|*diego*            | [2.42.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.42.0)                  | 14 January 2020   |
| garden-runc       | [1.19.9](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.19.9)            | 21 November 2019  |
|*loggregator*      | [106.3.5](https://github.com/cloudfoundry/loggregator-release/releases/tag/v106.3.5)          | 13 January 2020   |
|*loggregator-agent*| [5.3.4](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v5.3.4)        | 13 January 2020   |
|*log-cache*        | [2.6.8](https://github.com/cloudfoundry/log-cache-release/releases/tag/v2.6.8)                | 30 December 2019  |
| nats              | [32](https://github.com/cloudfoundry/nats-release/releases/tag/v32)                           | 11 December 2019  |
| routing           | [0.196.0](https://github.com/cloudfoundry/routing-release/releases/tag/0.196.0)               | 05 December 2019  |
|*statsd-injector*  | [1.11.13](https://github.com/cloudfoundry/statsd-injector-release/releases/tag/v1.11.13)      | 13 January 2020   |
|*cf-syslog-drain*  | [10.2.9](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v10.2.9)        | 13 January 2020   |
|*uaa*              | [74.13.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.13.0)                  | 13 January 2020   |
| silk              | [2.27.0](https://github.com/cloudfoundry/silk-release/releases/tag/2.27.0)                    | 02 December 2019  |
| bosh-dns-aliases  | [0.0.3](https://github.com/cloudfoundry/bosh-dns-aliases-release/releases/tag/v0.0.3)         | 24 October 2018   |
| cflinuxfs2        | [1.286.0](https://github.com/cloudfoundry/cflinuxfs2-release/releases/tag/v1.286.0)           | 12 June 2019      |
| app-autoscaler    | [2.0.0](https://github.com/cloudfoundry-incubator/app-autoscaler-release/releases/tag/v2.0.0) | 15 August 2019    |
| nfs-volume        | [2.3.0](https://github.com/cloudfoundry/nfs-volume-release/releases/tag/v2.3.0)               | 21 August 2019    |
| mapfs             | [1.2.0](https://github.com/cloudfoundry/mapfs-release/releases/tag/v1.2.0)                    | 15 July 2019      |
| postgres          | [3.2.0](https://github.com/cloudfoundry-community/postgres-boshrelease/releases/tag/v3.2.0)   | 19 September 2019 |
| haproxy           | [9.7.1](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/releases/tag/v9.7.1)    | 05 September 2019 |


# Buildpacks

| Release     | Version                                                                                   | Release Date     |
| ----------- | ----------------------------------------------------------------------------------------- | ---------------- |
|*binary*     | [1.0.36](https://github.com/cloudfoundry/binary-buildpack-release/releases/tag/1.0.36)    | 08 January 2020  |
|*dotnet-core*| [2.3.3](https://github.com/cloudfoundry/dotnet-core-buildpack-release/releases/tag/2.3.3) | 08 January 2020  |
|*go*         | [1.9.4](https://github.com/cloudfoundry/go-buildpack-release/releases/tag/1.9.4)          | 08 January 2020  |
| java        | [4.26](https://github.com/cloudfoundry/java-buildpack-release/releases/tag/4.26)          | 21 November 2019 |
|_nginx_      | [1.1.3](https://github.com/cloudfoundry/nginx-buildpack-release/releases/tag/1.1.3)       | 08 January 2020  |
|*nodejs*     | [1.7.8](https://github.com/cloudfoundry/nodejs-buildpack-release/releases/tag/1.7.8)      | 08 January 2020  |
|*php*        | [4.4.5](https://github.com/cloudfoundry/php-buildpack-release/releases/tag/4.4.5)         | 08 January 2020  |
|*python*     | [1.7.5](https://github.com/cloudfoundry/python-buildpack-release/releases/tag/1.7.5)      | 08 January 2020  |
|*r*          | [1.1.1](https://github.com/cloudfoundry/r-buildpack-release/releases/tag/1.1.1)           | 08 January 2020  |
|*ruby*       | [1.8.6](https://github.com/cloudfoundry/ruby-buildpack-release/releases/tag/1.8.6)        | 08 January 2020  |
|*staticfile* | [1.5.3](https://github.com/cloudfoundry/staticfile-buildpack-release/releases/tag/1.5.3)  | 08 January 2020  |

Note: Core Component and Buildpack releases in *italics* were updated as part of this kit release.