### PR TITLE
Pr bugfixes

### DIFF
--- a/kit.yml
+++ b/kit.yml
@@ -140,7 +140,7 @@ certificates:
       ssh_proxy_backends_tls: #was diego/certs/ssh_proxy_backend_tls
         valid_for: 1y
         names:     [ "ssh_proxy_backend_tls",
-                    "ssh_proxy.service.cf.internal" ]
+                    "ssh-proxy.service.cf.internal" ]
         usage:     [ client_auth ]
 
     log_cache/certs:

--- a/manifests/cf/bbs.yml
+++ b/manifests/cf/bbs.yml
@@ -5,7 +5,6 @@ meta:
     ca_cert:     (( grab meta.certs.cf_internal.diego_bbs_client.ca_cert ))
     client_cert: (( grab meta.certs.cf_internal.diego_bbs_client.cert ))
     client_key:  (( grab meta.certs.cf_internal.diego_bbs_client.key ))
-    require_tls: true
 
 instance_groups:
   - name: bbs

--- a/manifests/cf/cloud_controller.yml
+++ b/manifests/cf/cloud_controller.yml
@@ -273,7 +273,7 @@ meta:
         rules: (( grab params.cf_public_ips ))
 
     volume_services_enabled: true
-    temporary_disable_deployments: (( grab params.temporary_disable_cc_deployments || "false" ))
+    temporary_disable_deployments: (( grab params.temporary_disable_cc_deployments || false ))
 
   statsd_injector:
     enable_consul_service_registration: false

--- a/manifests/cf/router.yml
+++ b/manifests/cf/router.yml
@@ -29,6 +29,7 @@ instance_groups:
             status:
               user: health
               password: (( vault meta.vault "/gorouter/status:password" ))
+            route_services_secret: (( vault meta.vault "/gorouter/route_services:secret" ))
             tracing:
               enable_zipkin: true
           uaa:

--- a/manifests/cf/uaa.yml
+++ b/manifests/cf/uaa.yml
@@ -114,7 +114,7 @@ instance_groups:
                 authorized-grant-types: authorization_code
                 autoapprove: true
                 override: true
-                redirect-uri: (( concat "https://uaa.system." params.system_domain "/login" ))
+                redirect-uri: (( concat "https://uaa." params.system_domain "/login" ))
                 scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
                 secret: (( grab meta.uaa.ssh_proxy_secret ))
               tcp_emitter:


### PR DESCRIPTION
kit.yml: fixed typo in cert config
manifests/cf/bbs.yml: property is not present on that job. only rep. seems to be an accidental param
manifests/cf/router.yml: route services secret was missing previously which prevented routing services to work. uncovered while debugging cats
manifests/cf/uaa.yml: redirect uri used bad concatenation. removed duplicate "system" from value