### PR TITLE
Pr bosh lite

### DIFF
--- a/manifests/cf/base.yml
+++ b/manifests/cf/base.yml
@@ -103,6 +103,10 @@ params:
 
   autoscaler_network: cf-autoscaler
 
+  # Disable when running on bosh-lite, or docker_cpi
+  set_kernel_parameters: true
+  apparmor_profile: ~ # set to "" on bosh-lite
+
 instance_groups:
   - name: nats
     instances: (( grab params.nats_instances ))

--- a/manifests/cf/bbs.yml
+++ b/manifests/cf/bbs.yml
@@ -13,6 +13,7 @@ instance_groups:
       - name: bbs
         release: diego
         properties:
+          set_kernel_parameters: (( params.set_kernel_parameters ))
           bpm:
             enabled: true
           diego:
@@ -69,6 +70,7 @@ instance_groups:
       - name: locket
         release: diego
         properties:
+          set_kernel_parameters: (( params.set_kernel_parameters ))
           enable_consul_service_registration: false
           tls: (( grab meta.certs.cf_internal.diego_locket_server ))
           diego:

--- a/manifests/cf/bbs.yml
+++ b/manifests/cf/bbs.yml
@@ -13,7 +13,7 @@ instance_groups:
       - name: bbs
         release: diego
         properties:
-          set_kernel_parameters: (( params.set_kernel_parameters ))
+          set_kernel_parameters: (( grab params.set_kernel_parameters ))
           bpm:
             enabled: true
           diego:
@@ -70,7 +70,7 @@ instance_groups:
       - name: locket
         release: diego
         properties:
-          set_kernel_parameters: (( params.set_kernel_parameters ))
+          set_kernel_parameters: (( grab params.set_kernel_parameters ))
           enable_consul_service_registration: false
           tls: (( grab meta.certs.cf_internal.diego_locket_server ))
           diego:

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -40,7 +40,7 @@ instance_groups:
     - name: rep
       release: diego
       properties:
-        set_kernel_parameters: (( params.set_kernel_parameters ))
+        set_kernel_parameters: (( grab params.set_kernel_parameters ))
         bpm:
           enabled: true
         diego:

--- a/manifests/cf/cell.yml
+++ b/manifests/cf/cell.yml
@@ -27,6 +27,7 @@ instance_groups:
       release: garden-runc
       properties:
         garden:
+          apparmor_profile: (( grab params.apparmor_profile ))
           containerd_mode: true
           default_container_grace_time: 0
           destroy_containers_on_start: true
@@ -39,6 +40,7 @@ instance_groups:
     - name: rep
       release: diego
       properties:
+        set_kernel_parameters: (( params.set_kernel_parameters ))
         bpm:
           enabled: true
         diego:


### PR DESCRIPTION
Add BOSH Lite Support with params for garden and apparmor. Mostly related to avoid setting kernel flags for garden when running in docker

https://github.com/cloudfoundry-incubator/cfdev-builder/blob/master/v2/operations/cf/bosh-lit.yml#L6-L8
https://github.com/cloudfoundry/cf-deployment/blob/master/operations/bosh-lite.yml#L117-L132

