### PR TITLE
Add proper key usage to haproxy certs to avoid strict browser complaints

### DIFF
--- a/overlay/routing/haproxy-tls.yml
+++ b/overlay/routing/haproxy-tls.yml
@@ -36,6 +36,7 @@ variables:
     - '*.((system_domain))'
     ca: haproxy_ca
     common_name: haproxySSL
+    extended_key_usage: [server_auth,client_auth]
   type: certificate
 
 exodus:


### PR DESCRIPTION
Add key usage to haproxy generated cert