### PR TITLE
Set ops files to merge after native kit features

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -67,18 +67,20 @@ fi
 # Check for ops features
 declare -a features
 features=()
+declare -a ops_files
+ops_files=()
 
 for feature in $GENESIS_REQUESTED_FEATURES; do
   if [[ "$feature" =~ ^cf-deployment-version- ]] ; then
     : # Dealt with above - skip here
   elif [[ $feature =~ cf-deployment/.* ]] ; then
     if [[ -f "$feature.yml" ]] ; then
-      manifest+=( "$feature.yml" )
+      ops_files+=( "$feature.yml" )
     else
       bail "#R[ERROR]} Kit $GENESIS_KIT_NAME/$GENESIS_KIT_VERSION does not support the $feature feature" ""
     fi
   elif [[ -f "$GENESIS_ROOT/ops/$feature.yml" ]] ; then
-    manifest+=( "$GENESIS_ROOT/ops/$feature.yml" )
+    ops_files+=( "$GENESIS_ROOT/ops/$feature.yml" )
   else
     features+=( "$feature" )
   fi
@@ -360,6 +362,8 @@ warden)
   manifest+=( "cf-deployment/operations/bosh-lite.yml" )
   ;;
 esac
+
+manifest=( "${manifest[@]}" "${ops_files[@]}" )
 
 echo "${manifest[@]}"
 


### PR DESCRIPTION
Ran into problems with kit features expecting values to exist that did not due to ops files removing those values. Suggest that we swap the merge order to merge `cf-deployment/operations` files after our native kit features. This solution came with help from @daviddob. Open for discussion about this problem and alternative solutions.