### PR TITLE
Add IaaS ops files to bare

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -345,21 +345,23 @@ done
 #
 
 # Deal with IaaS peculiarities
-case "$cpi" in
-aws)
-  manifest+=( "cf-deployment/operations/aws.yml" )
-  ;;
-azure)
-  manifest+=( \
-    "cf-deployment/operations/azure.yml"
-    "operations/scale-to-one-az.yml" \
-    "operations/azure-availability_sets.yml" \
-  )
-  ;;
-warden)
-  manifest+=( "cf-deployment/operations/bosh-lite.yml" )
-  ;;
-esac
+if ! want_feature  "bare" ; then
+  case "$cpi" in
+  aws)
+    manifest+=( "cf-deployment/operations/aws.yml" )
+    ;;
+  azure)
+    manifest+=( \
+      "cf-deployment/operations/azure.yml"
+      "operations/scale-to-one-az.yml" \
+      "operations/azure-availability_sets.yml" \
+    )
+    ;;
+  warden)
+    manifest+=( "cf-deployment/operations/bosh-lite.yml" )
+    ;;
+  esac
+fi
 
 echo "${manifest[@]}"
 


### PR DESCRIPTION
This adds the IaaS related ops files to the things that are ignored when `bare` is specified. 

This is the least that should be done. Discussing with some others, it might be worth just excluding these all together. Allow them to be specified specifically as with other ops files.

I invite discussion and alternative solutions from the community. 