### PR TITLE
make starting_container_count_maximum configurable through params

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -47,6 +47,10 @@ runtime config.
     when pushing apps.  The options are currently `cflinuxfs2` and
     `cflinuxfs3`.  Defaults to `cflinuxfs3`
 
+  - `starting_container_count_maximum` - Maximum number of inflight 
+     container starts allowed globally. Value of 0 or less indicates
+     no limit. Default is 0.
+
   - `availability_zones` - Which AZs to deploy to. Defaults to 
     `[z1, z2, z3]`
 

--- a/manifests/cf/diego.yml
+++ b/manifests/cf/diego.yml
@@ -21,6 +21,9 @@ meta:
       droplet_destinations:
         cflinuxfs3: /home/vcap
 
+params:
+  starting_container_count_maximum: 0
+
 instance_groups:
   - name: diego
     jobs:
@@ -31,6 +34,7 @@ instance_groups:
           diego:
             auctioneer:
               skip_consul_lock: true
+              starting_container_count_maximum: (( grab params.starting_container_count_maximum ))
               ca_cert:     (( grab meta.certs.cf_internal.diego_auctioneer_server.ca_cert ))
               server_cert: (( grab meta.certs.cf_internal.diego_auctioneer_server.cert ))
               server_key:  (( grab meta.certs.cf_internal.diego_auctioneer_server.key ))


### PR DESCRIPTION
Setting a limit on `starting_container_count_maximum` prevents Diego from scheduling too much new work for your platform to handle concurrently. This is helpful when your infrastructure is not sized for a large number of concurrent cold starts.

This PR makes `starting_container_count_maximum`  configurable through params.