### PR TITLE
Fixed typo for UAA DB creds & Bumped up release versions

### DIFF
--- a/overlay/addons/migration.yml
+++ b/overlay/addons/migration.yml
@@ -12,8 +12,8 @@ meta:
       name: ccdb
       user: ccadmin
     uaa:
-      name: uuadb
-      user: uuaadmin
+      name: uaadb
+      user: uaaadmin
     diego:
       name: diegodb
       user: diegoadmin


### PR DESCRIPTION
1. There was a typo in the UAA database default creds. `uaadb` was spelled `uuadb` & `uaaadmin` was spelled `uuaadmin`
2. This PR also fixes #152 