### PR TITLE
Fix features hook for migrated env

### DIFF
--- a/hooks/features
+++ b/hooks/features
@@ -10,5 +10,5 @@ if [[ $migrated_v1_env != "1" ]] ; then
     migrated_v1_env=1
   fi
 fi
-[[ -n "${migrated_v1_env:-}" ]] && echo "+migrated_v1_env"
+[[ -n "${migrated_v1_env:-}" ]] && echo "+migrated-v1-env"
 exit 0


### PR DESCRIPTION
Got the following error during migration from 1.10.1 to v2

```
[snw-nahmad-lab] running manifest viability checks...
[ERROR] The +migrated_v1_env feature is invalid. See the manual for list of valid features.
Cannot continue - fix your snw-nahmad-lab.yml file to resolve these issues.
[ERROR] Could not determine which YAML files to merge: 'blueprint' hook exited with 1:
```
This PR fixes it.