### PR TITLE
Migration indicator

### DIFF
--- a/hooks/addon
+++ b/hooks/addon
@@ -75,6 +75,15 @@ smoketest)
   "$GENESIS_BOSH_COMMAND" -e "$BOSH_ENVIRONMENT" -d "$BOSH_DEPLOYMENT" run-errand smoke_tests
   ;;
 
+remigrate)
+  # Migrate the secrets
+  set -e
+  source ./hooks/migrate-to-2.0
+  validate_expected_vault_secrets
+  correct_x509_certs
+  migrate_credentials_to_credhub
+  ;;
+
 *)
   echo "Unrecognized Cloud Foundry Genesis Kit addon."
   list

--- a/hooks/addon
+++ b/hooks/addon
@@ -51,7 +51,7 @@ login)
 
 remigrate)
   # Migrate the secrets
-  set -e
+
   #shellcheck disable=SC1091
   source ./hooks/migrate-to-2.0
   validate_expected_vault_secrets

--- a/hooks/pre-deploy
+++ b/hooks/pre-deploy
@@ -6,6 +6,7 @@ set +e
 if [[ -n "${version:-}" ]] && ! new_enough "${version}" "2.0.0-rc1" ; then
 
   # Migrate the secrets
+  echo "Detected upgrading from version '${version}'. Migrating secrets from Vault to Credhub"
   set -e
   source ./hooks/migrate-to-2.0
   validate_expected_vault_secrets


### PR DESCRIPTION
When the migration to Credhub is about to happen, we should display a message.

When something is not right, like BOSH is pre-Credhub version the message would look like

```
Preflight ok, initiating BOSH deploy...
You are not currently authenticated. Please log in to continue.
[ERROR] Cannot continue with deployment: 'pre-deploy' hook for lab-test evironment exited 1.
```

Which does not indicate that Credhub is printing the error