### PR TITLE
Update cf-deployment.yml to v6.25.0 of cf-deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.tar.gz
+.DS_Store

--- a/cf-deployment/cf-deployment.yml
+++ b/cf-deployment/cf-deployment.yml
@@ -1,6 +1,6 @@
 ---
 name: cf
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 update:
   canaries: 1
   canary_watch_time: 30000-1200000
@@ -12,6 +12,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   exclude:
     jobs:
     - name: smoke_tests
@@ -38,6 +39,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     release: loggregator-agent
@@ -56,6 +58,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   exclude:
     jobs:
     - name: smoke_tests
@@ -85,6 +88,7 @@ addons:
   include:
     stemcell:
       - os: ubuntu-xenial
+      - os: ubuntu-bionic
   exclude:
     jobs:
     - name: smoke_tests
@@ -113,6 +117,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -134,6 +139,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -157,9 +163,11 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
+
 - name: bosh-dns-aliases
   jobs:
   - name: bosh-dns-aliases
@@ -693,7 +701,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_cc_service_key_client_secret))"
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -741,7 +749,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_emitter_secret))"
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: "((uaa_clients_tcp_router_secret))"
         ca_certs:
@@ -1256,6 +1264,10 @@ instance_groups:
           ca: ((cf_app_sd_server_tls.ca))
         server:
           tls: ((cf_app_sd_server_tls))
+      nats:
+        tls_enabled: true
+        cert_chain: ((nats_client_cert.certificate))
+        private_key: ((nats_client_cert.private_key))
     release: cf-networking
   - name: statsd_injector
     release: statsd-injector
@@ -1369,6 +1381,10 @@ instance_groups:
         route_services_secret: "((router_route_services_secret))"
         tracing:
           enable_zipkin: true
+      nats:
+        tls_enabled: true
+        cert_chain: "((nats_client_cert.certificate))"
+        private_key: "((nats_client_cert.private_key))"
       routing_api:
         enabled: true
       uaa:
@@ -1476,6 +1492,11 @@ instance_groups:
       reverse_log_proxy: {from: reverse_log_proxy}
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: ((log_cache_nozzle_metrics_tls.ca))
+        cert: ((log_cache_nozzle_metrics_tls.certificate))
+        key: ((log_cache_nozzle_metrics_tls.private_key))
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: ((logs_provider.ca))
@@ -2512,6 +2533,17 @@ variables:
     extended_key_usage:
     - server_auth
 
+- name: log_cache_nozzle_metrics_tls
+  type: certificate
+  update_mode: converge
+  options:
+    ca: metric_scraper_ca
+    common_name: log_cache_nozzle_metrics
+    alternative_names:
+    - log_cache_nozzle_metrics
+    extended_key_usage:
+    - server_auth
+
 - name: log_cache_cf_auth_proxy_metrics_tls
   type: certificate
   update_mode: converge
@@ -2704,130 +2736,130 @@ variables:
 
 releases:
 - name: binary-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
   sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
   sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"

--- a/spec/credhub/app-autoscaler-integration.yml
+++ b/spec/credhub/app-autoscaler-integration.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/availability-zones.yml
+++ b/spec/credhub/availability-zones.yml
@@ -136,6 +136,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/bare.yml
+++ b/spec/credhub/bare.yml
@@ -149,6 +149,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/blobstore-aws.yml
+++ b/spec/credhub/blobstore-aws.yml
@@ -140,6 +140,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/blobstore-azure.yml
+++ b/spec/credhub/blobstore-azure.yml
@@ -140,6 +140,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/blobstore-gcp.yml
+++ b/spec/credhub/blobstore-gcp.yml
@@ -140,6 +140,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/blobstore-minio.yml
+++ b/spec/credhub/blobstore-minio.yml
@@ -140,6 +140,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/container-routing-integrity.yml
+++ b/spec/credhub/container-routing-integrity.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/dns-service-discovery.yml
+++ b/spec/credhub/dns-service-discovery.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/haproxy-self-signed.yml
+++ b/spec/credhub/haproxy-self-signed.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/haproxy-tls.yml
+++ b/spec/credhub/haproxy-tls.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/haproxy.yml
+++ b/spec/credhub/haproxy.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/loggregator-forwarder-agent.yml
+++ b/spec/credhub/loggregator-forwarder-agent.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/mysql-db.yml
+++ b/spec/credhub/mysql-db.yml
@@ -136,6 +136,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/native-garden-runc.yml
+++ b/spec/credhub/native-garden-runc.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/no-tcp-routers.yml
+++ b/spec/credhub/no-tcp-routers.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/postgres-db.yml
+++ b/spec/credhub/postgres-db.yml
@@ -136,6 +136,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/router-synergy.yml
+++ b/spec/credhub/router-synergy.yml
@@ -153,6 +153,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/routing-api.yml
+++ b/spec/credhub/routing-api.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/credhub/small-footprint.yml
+++ b/spec/credhub/small-footprint.yml
@@ -145,6 +145,10 @@ log_cache_metrics_tls:
   ca: <!{credhub}:log_cache_metrics_tls.ca!>
   certificate: <!{credhub}:log_cache_metrics_tls.certificate!>
   private_key: <!{credhub}:log_cache_metrics_tls.private_key!>
+log_cache_nozzle_metrics_tls:
+  ca: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+  certificate: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+  private_key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
 log_cache_proxy_tls:
   ca: <!{credhub}:log_cache_proxy_tls.ca!>
   certificate: <!{credhub}:log_cache_proxy_tls.certificate!>

--- a/spec/deployments/postgres-db.yml
+++ b/spec/deployments/postgres-db.yml
@@ -17,4 +17,3 @@ params:
   bbsdb_host: test bbsdb-host
   bbsdb_user: test-bbsdb-user
   bbsdb_password: test-bbsdb-password
-

--- a/spec/results/app-autoscaler-integration.yml
+++ b/spec/results/app-autoscaler-integration.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -330,6 +337,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: app-autoscaler-integration
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -337,6 +345,7 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: app-autoscaler-integration
+  is_director: false
   loggregator_ca: <!{credhub}:loggregator_ca.certificate!>
   loggregator_tls_agent_cert: <!{credhub}:loggregator_tls_agent.certificate!>
   loggregator_tls_agent_key: <!{credhub}:loggregator_tls_agent.private_key!>
@@ -346,6 +355,7 @@ exodus:
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/app/autoscaler/integration/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -667,7 +677,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -715,7 +725,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1392,6 +1402,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1511,6 +1525,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1646,6 +1664,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2048,141 +2071,142 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: app-autoscaler-integration-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
-  sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
-  version: "43"
+  version: '43'
+  sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
+
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/availability-zones.yml
+++ b/spec/results/availability-zones.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: availability-zones
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: postgres-db,ssh-proxy-on-routers
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/availability/zones/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -593,7 +603,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -641,7 +651,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1336,6 +1346,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1455,6 +1469,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1626,6 +1644,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2032,133 +2055,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: availability-zones-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/bare.yml
+++ b/spec/results/bare.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - system.cf.testing.examle
   apps_domain: system.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: bare
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: partitioned-network,bare
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/bare/cf/uaa/client_secrets:firehose
 instance_groups:
 - azs:
@@ -678,7 +688,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -726,7 +736,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1410,6 +1420,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1529,6 +1543,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1664,6 +1682,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2065,137 +2088,137 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: bare-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/blobstore-aws.yml
+++ b/spec/results/blobstore-aws.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: blobstore-aws
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: aws-blobstore
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/blobstore/aws/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1309,6 +1319,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1428,6 +1442,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1563,6 +1581,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -1965,133 +1988,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: blobstore-aws-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2099,7 +2122,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/blobstore-azure.yml
+++ b/spec/results/blobstore-azure.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: blobstore-azure
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: azure-blobstore
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/blobstore/azure/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1309,6 +1319,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1428,6 +1442,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1563,6 +1581,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -1965,133 +1988,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: blobstore-azure-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2099,7 +2122,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/blobstore-gcp.yml
+++ b/spec/results/blobstore-gcp.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: blobstore-gcp
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: gcp-blobstore
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/blobstore/gcp/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1309,6 +1319,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1428,6 +1442,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1563,6 +1581,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -1965,133 +1988,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: blobstore-gcp-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2099,7 +2122,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/blobstore-minio.yml
+++ b/spec/results/blobstore-minio.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: blobstore-minio
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: minio-blobstore
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/blobstore/minio/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1345,6 +1355,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1464,6 +1478,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1599,6 +1617,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2001,133 +2024,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: blobstore-minio-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2135,7 +2158,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/container-routing-integrity.yml
+++ b/spec/results/container-routing-integrity.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: container-routing-integrity
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: container-routing-integrity
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/container/routing/integrity/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1381,6 +1391,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1500,6 +1514,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1635,6 +1653,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2037,133 +2060,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: container-routing-integrity-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2171,7 +2194,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/dns-service-discovery.yml
+++ b/spec/results/dns-service-discovery.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -330,6 +337,7 @@ exodus:
     name: apps.internal
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: dns-service-discovery
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -337,10 +345,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: dns-service-discovery
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/dns/service/discovery/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -658,7 +668,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -706,7 +716,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1393,6 +1403,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1504,6 +1518,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1644,6 +1662,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2041,133 +2064,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: dns-service-discovery-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
 - name: cf-smoke-tests
   sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
 - name: credhub
   sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  sha1: 713dfd0486f32073281129ab45961031833d7998
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2175,7 +2198,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/haproxy-self-signed.yml
+++ b/spec/results/haproxy-self-signed.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: haproxy-self-signed
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: haproxy,self-signed
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/haproxy/self/signed/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1381,6 +1391,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1522,6 +1536,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1655,6 +1673,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2057,133 +2080,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: haproxy-self-signed-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: haproxy
   sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=9.8.0
@@ -2195,7 +2218,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/haproxy-tls.yml
+++ b/spec/results/haproxy-tls.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: haproxy-tls
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,11 +343,13 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: haproxy,tls
+  is_director: false
   runtime_network: cf-runtime
   self-signed: false
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/haproxy/tls/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -657,7 +667,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -705,7 +715,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1390,6 +1400,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1528,6 +1542,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1666,6 +1684,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2063,133 +2086,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: haproxy-tls-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: haproxy
   sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=9.8.0
@@ -2201,7 +2224,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/haproxy.yml
+++ b/spec/results/haproxy.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: haproxy
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: haproxy
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/haproxy/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1389,6 +1399,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1522,6 +1536,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1660,6 +1678,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2057,133 +2080,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: haproxy-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: haproxy
   sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=9.8.0
@@ -2195,7 +2218,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/loggregator-forwarder-agent.yml
+++ b/spec/results/loggregator-forwarder-agent.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: loggregator-forwarder-agent
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: loggregator-forwarder-agent
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/loggregator/forwarder/agent/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1389,6 +1399,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1500,6 +1514,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1640,6 +1658,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2037,133 +2060,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: loggregator-forwarder-agent-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
 - name: cf-smoke-tests
   sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
 - name: credhub
   sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  sha1: 713dfd0486f32073281129ab45961031833d7998
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2171,7 +2194,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/mysql-db.yml
+++ b/spec/results/mysql-db.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: mysql-db
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: mysql-db
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/mysql/db/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -589,7 +599,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -637,7 +647,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1329,6 +1339,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1448,6 +1462,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1583,6 +1601,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -1985,133 +2008,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: mysql-db-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/native-garden-runc.yml
+++ b/spec/results/native-garden-runc.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: native-garden-runc
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: native-garden-runc
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/native/garden/runc/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1381,6 +1391,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1500,6 +1514,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1635,6 +1653,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2036,133 +2059,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: native-garden-runc-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2170,7 +2193,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/no-tcp-routers.yml
+++ b/spec/results/no-tcp-routers.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.example
   apps_domain: run.cf.testing.example
   base_domain: cf.testing.example
+  bosh: no-tcp-routers
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: no-tcp-routers
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.example
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/no/tcp/routers/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1389,6 +1399,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1500,6 +1514,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1606,6 +1624,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2003,133 +2026,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: no-tcp-routers-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
 - name: cf-smoke-tests
   sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
 - name: credhub
   sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  sha1: 713dfd0486f32073281129ab45961031833d7998
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2137,7 +2160,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/postgres-db.yml
+++ b/spec/results/postgres-db.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: postgres-db
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: postgres-db
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/postgres/db/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -589,7 +599,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -637,7 +647,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1329,6 +1339,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1448,6 +1462,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1583,6 +1601,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -1985,133 +2008,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: postgres-db-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/router-synergy.yml
+++ b/spec/results/router-synergy.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -330,6 +337,7 @@ exodus:
     name: apps.internal
   apps_domain: run.cf.testing.example
   base_domain: cf.testing.example
+  bosh: router-synergy
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -337,11 +345,13 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: small-footprint,ssh-proxy-on-routers,haproxy,self-signed,tls,no-tcp-routers,cf-deployment/operations/enable-service-discovery
+  is_director: false
   runtime_network: cf-runtime
   self-signed: true
   system_domain: system.cf.testing.example
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/router/synergy/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -655,7 +665,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -703,7 +713,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1379,6 +1389,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1523,6 +1537,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1655,6 +1673,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2053,133 +2076,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: router-synergy-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: haproxy
   sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=9.8.0
@@ -2191,7 +2214,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/routing-api.yml
+++ b/spec/results/routing-api.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: routing-api
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: routing-api
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/routing/api/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -656,7 +666,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -704,7 +714,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1389,6 +1399,10 @@ instance_groups:
             ca: <!{credhub}:cf_app_sd_server_tls.ca!>
             certificate: <!{credhub}:cf_app_sd_server_tls.certificate!>
             private_key: <!{credhub}:cf_app_sd_server_tls.private_key!>
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
     release: cf-networking
   - name: statsd_injector
     properties:
@@ -1500,6 +1514,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1640,6 +1658,11 @@ instance_groups:
           ca_cert: <!{credhub}:logs_provider.ca!>
           cert: <!{credhub}:logs_provider.certificate!>
           key: <!{credhub}:logs_provider.private_key!>
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
     release: log-cache
   - name: route_registrar
     properties:
@@ -2037,133 +2060,133 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: routing-api-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
 - name: cf-smoke-tests
   sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
 - name: credhub
   sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  sha1: 713dfd0486f32073281129ab45961031833d7998
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2171,7 +2194,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000

--- a/spec/results/small-footprint.yml
+++ b/spec/results/small-footprint.yml
@@ -6,6 +6,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggregator_agent
     properties:
@@ -27,6 +28,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-forwarder-agent
     properties:
@@ -48,6 +50,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: loggr-syslog-agent
     properties:
@@ -76,6 +79,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: prom_scraper
     properties:
@@ -99,6 +103,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-discovery-registrar
     properties:
@@ -119,6 +124,7 @@ addons:
   include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: metrics-agent
     properties:
@@ -141,6 +147,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-xenial
+    - os: ubuntu-bionic
   jobs:
   - name: bpm
     release: bpm
@@ -328,6 +335,7 @@ exodus:
   - run.cf.testing.examle
   apps_domain: run.cf.testing.examle
   base_domain: cf.testing.examle
+  bosh: small-footprint
   cf-deployment-date: 2021-Mar-11 16:27:59 UTC
   cf-deployment-url: https://github.com/cloudfoundry/cf-deployment/releases/tag/v16.7.0
   cf-deployment-version: 16.7.0
@@ -335,10 +343,12 @@ exodus:
   db_network: cf-core
   edge_network: cf-edge
   features: haproxy,small-footprint
+  is_director: false
   runtime_network: cf-runtime
   system_domain: system.cf.testing.examle
   system_org: system
   system_space: system
+  use_create_env: false
   vaulted_uaa_clients: /secret/small/footprint/cf/uaa/client_secrets:firehose
 features:
   randomize_az_placement: true
@@ -652,7 +662,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_cc_service_key_client_secret!>
           cf:
-            access-token-validity: 600
+            access-token-validity: 1200
             authorities: uaa.none
             authorized-grant-types: password,refresh_token
             override: true
@@ -700,7 +710,7 @@ instance_groups:
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_emitter_secret!>
           tcp_router:
-            authorities: routing.routes.read
+            authorities: routing.routes.read,routing.router_groups.read
             authorized-grant-types: client_credentials
             secret: <!{credhub}:uaa_clients_tcp_router_secret!>
         jwt:
@@ -1374,6 +1384,10 @@ instance_groups:
     release: capi
   - name: service-discovery-controller
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       dnshttps:
         client:
           ca: <!{credhub}:cf_app_sd_server_tls.ca!>
@@ -1513,6 +1527,10 @@ instance_groups:
   jobs:
   - name: gorouter
     properties:
+      nats:
+        cert_chain: <!{credhub}:nats_client_cert.certificate!>
+        private_key: <!{credhub}:nats_client_cert.private_key!>
+        tls_enabled: true
       router:
         backends:
           cert_chain: <!{credhub}:gorouter_backend_tls.certificate!>
@@ -1644,6 +1662,11 @@ instance_groups:
         from: reverse_log_proxy
     name: log-cache-nozzle
     properties:
+      metrics:
+        ca_cert: <!{credhub}:log_cache_nozzle_metrics_tls.ca!>
+        cert: <!{credhub}:log_cache_nozzle_metrics_tls.certificate!>
+        key: <!{credhub}:log_cache_nozzle_metrics_tls.private_key!>
+        server_name: log_cache_nozzle_metrics
       logs_provider:
         tls:
           ca_cert: <!{credhub}:logs_provider.ca!>
@@ -2042,137 +2065,137 @@ instance_groups:
   - name: cf-core
   stemcell: default
   vm_type: minimal
-manifest_version: v16.7.0
+manifest_version: v16.25.0
 name: small-footprint-cf
 releases:
 - name: binary-buildpack
-  sha1: 0269a613be68f988682bbf56504b78477965b1c4
-  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.36
-  version: 1.0.36
+  url: https://bosh.io/d/github.com/cloudfoundry/binary-buildpack-release?v=1.0.40
+  version: 1.0.40
+  sha1: 6e1ff3753ac5a86e968546222bbbaaba1264d938
 - name: bpm
-  sha1: dcf0582d838a73de29da273552ae79ac3098ee8b
-  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9
-  version: 1.1.9
+  url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.14
+  version: 1.1.14
+  sha1: 6e1187b180c3d8e6d3dafa2861147a59d4ede27e
 - name: capi
-  sha1: 0eb88c2aedf9b7a9b10b6c1bfd6a21900403629e
-  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.107.0
-  version: 1.107.0
+  url: https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.119.0
+  version: 1.119.0
+  sha1: f57b95580fa2f555ee7be7f17a4be4db6a1fea34
 - name: cf-networking
-  sha1: dd902b4a23af60c5a1b314969c6b88aac8b5da7d
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-networking-release?v=2.39.0
+  version: 2.39.0
+  sha1: ad1c97f03736524128c313f54b3cae16bf5bd986
 - name: cf-smoke-tests
-  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
   url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=41.0.2
   version: 41.0.2
+  sha1: b1eb4efe1f88367708ac8cbb08dc78a09dde9c4b
 - name: cflinuxfs3
-  sha1: bc56af1c9258dcb561d85a3b43b2c5df64c0aab2
-  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.229.0
-  version: 0.229.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.262.0
+  version: 0.262.0
+  sha1: 0a7bb8199a63a667569c5d1e5a3e0b1d4a7b96d2
 - name: credhub
-  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.9.0
   version: 2.9.0
+  sha1: 36d3a92588c33bc3a7ce54cd4714c96cc7d1bee2
 - name: diego
-  sha1: 5e8e6600cc6cf69dd25ce76bda6a144cc00bfdd7
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.49.0
-  version: 2.49.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.53.0
+  version: 2.53.0
+  sha1: 85f71928d7d0f89e04cdf386c2ab4c3d485fa468
 - name: dotnet-core-buildpack
-  sha1: 67750e38b7ede093b4551ee7c78b3a55677d0f75
-  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.24
-  version: 2.3.24
+  url: https://bosh.io/d/github.com/cloudfoundry/dotnet-core-buildpack-release?v=2.3.34
+  version: 2.3.34
+  sha1: 60442fcaad7552b3bc26e61f77779deef46913b8
 - name: garden-runc
-  sha1: b02ae334deb7cae07152d3e26b231b2306e47ecf
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.19
-  version: 1.19.19
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.30
+  version: 1.19.30
+  sha1: d06a32a2e50faabd2df328619384089d9418f355
 - name: go-buildpack
-  sha1: e793231bbad00ad5a812937bbf116e168d802909
-  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.27
-  version: 1.9.27
+  url: https://bosh.io/d/github.com/cloudfoundry/go-buildpack-release?v=1.9.36
+  version: 1.9.36
+  sha1: b1a756e21b7a9cbf3c04e66402657a41fce7d7e6
 - name: java-buildpack
-  sha1: 87c65cc20fcaddd67888009e47098235801d1088
-  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.36
-  version: "4.36"
+  url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.42
+  version: "4.42"
+  sha1: 437779c708c437f8e60b1c92f218c4d01e809b6c
 - name: loggregator
-  sha1: 1a4c1a9988d4f83af515daaa44f57ee0c3b1859d
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.5.0
-  version: 106.5.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.6.0
+  version: 106.6.0
+  sha1: 9eb81ddf174e826a5f4e59bc4dc6bda9007495eb
 - name: metrics-discovery
-  sha1: c414dd33b34231dfb8f655ed77c54a2fc21775fa
-  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.3
-  version: 3.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/metrics-discovery-release?v=3.0.6
+  version: 3.0.6
+  sha1: 073f13a065ca15e7c0c435ec71f88675f4e704d3
 - name: nats
-  sha1: 269e60d95ec9694e6807a7f8e32634c7e2651232
-  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=39
-  version: "39"
+  url: https://bosh.io/d/github.com/cloudfoundry/nats-release?v=40
+  version: "40"
+  sha1: c8b82cebfd24e65b1079b66435aac4b48f4aa3c5
 - name: nginx-buildpack
-  sha1: 4b68784ba88bea02b77620e96745c44a876eb7b5
-  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.21
-  version: 1.1.21
+  url: https://bosh.io/d/github.com/cloudfoundry/nginx-buildpack-release?v=1.1.32
+  version: 1.1.32
+  sha1: 8adeefbcc10e25776d364f17caa4a3fdab8c3334
 - name: r-buildpack
-  sha1: 1ba366d916c33e7fe8c2de8b9b8458776a63cd6c
-  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.13
-  version: 1.1.13
+  url: https://bosh.io/d/github.com/cloudfoundry/r-buildpack-release?v=1.1.22
+  version: 1.1.22
+  sha1: 11e2fcb1f349c88a3cc2156d55730c7eb4d143ce
 - name: nodejs-buildpack
-  sha1: 39b95568d65b0a45abd45ee136b11ac3074acc1d
-  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.44
-  version: 1.7.44
+  url: https://bosh.io/d/github.com/cloudfoundry/nodejs-buildpack-release?v=1.7.62
+  version: 1.7.62
+  sha1: 7be381c1e879493239619ad708d258424fe0b626
 - name: php-buildpack
-  sha1: ac3ff1bb510e9e20afa7c6b2cb12b9b5d07d1ecb
-  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.33
-  version: 4.4.33
+  url: https://bosh.io/d/github.com/cloudfoundry/php-buildpack-release?v=4.4.46
+  version: 4.4.46
+  sha1: 9f3e8de97495074ebd0362623f23d6884297fab9
 - name: pxc
-  sha1: bbcd3e1696f66b6640be1f817347bd6e0b90459f
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.33.0
-  version: 0.33.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/pxc-release?v=0.39.0
+  version: 0.39.0
+  sha1: 526751fd60912322aafbb2b25f744b732501493f
 - name: python-buildpack
-  sha1: 9d35ce378724bb049e0fe21986fe46db1e0f4a37
-  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.32
-  version: 1.7.32
+  url: https://bosh.io/d/github.com/cloudfoundry/python-buildpack-release?v=1.7.46
+  version: 1.7.46
+  sha1: 73f6790af87c0945e9ab91036817b325b9976ee5
 - name: routing
-  sha1: 121f4bd24103b87f20b863e42d0a0e45aa32f6a5
-  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.212.0
-  version: 0.212.0
+  url: https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.225.0
+  version: 0.225.0
+  sha1: a5b7f3b746cfa169f466c2b682db296ab8dcd0ad
 - name: ruby-buildpack
-  sha1: d76692dc9582e8dd3604e124031f7ce549ef42ef
-  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.33
-  version: 1.8.33
+  url: https://bosh.io/d/github.com/cloudfoundry/ruby-buildpack-release?v=1.8.47
+  version: 1.8.47
+  sha1: f6b4d39e0df49746cc4a41c308e6737e6c82764e
 - name: silk
-  sha1: 24e7665076efcf9666962c9c46885f37dfe72b0b
-  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.35.0
-  version: 2.35.0
+  url: https://bosh.io/d/github.com/cloudfoundry/silk-release?v=2.39.0
+  version: 2.39.0
+  sha1: 7728d15d5e0bc6c0a0a2124f123c99baf79b6ff7
 - name: staticfile-buildpack
-  sha1: 2325b55f5752e52242eb05adfa47d69d2be0562e
-  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.16
-  version: 1.5.16
+  url: https://bosh.io/d/github.com/cloudfoundry/staticfile-buildpack-release?v=1.5.25
+  version: 1.5.25
+  sha1: 713dfd0486f32073281129ab45961031833d7998
 - name: statsd-injector
-  sha1: a0a2d33c6ab7d8fec8c017ea6f2c5a344af1407c
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.15
-  version: 1.11.15
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.11.16
+  version: 1.11.16
+  sha1: 4ca93a4ab1a65a2b7cb2c84d27b6cbd725a914a9
 - name: uaa
-  sha1: d843716497e5b2610a2e4fe7645f1cd77c86e788
-  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.0.0
-  version: 75.0.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=75.8.0
+  version: 75.8.0
+  sha1: f5bba2e0a3df5adddade37e32ba05a4bb06a002c
 - name: loggregator-agent
-  sha1: 7210bac9c456bf20fd6de2175c562e443f249249
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.2.0
-  version: 6.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+  version: 6.3.4
+  sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
 - name: log-cache
-  sha1: e08ce756f0760c013d5d6fecfbdc4546a585f789
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.10.0
-  version: 2.10.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.11.4
+  version: 2.11.4
+  sha1: f91e89e494ac4f9010f33a9567335dc713287fec
 - name: bosh-dns-aliases
-  sha1: b0d0a0350ed87f1ded58b2ebb469acea0e026ccc
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
-  version: 0.0.3
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4
+  version: 0.0.4
+  sha1: 55b3dced813ff9ed92a05cda02156e4b5604b273
 - name: cf-cli
-  sha1: b89a74153143fe8af2c681ed0cd64185ae61f5f9
-  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.32.0
-  version: 1.32.0
+  url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
+  version: 1.34.0
+  sha1: c3d11f473d4518505e2a671d8ad6a553e1b1c1ca
 - name: haproxy
-  sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/haproxy-boshrelease?v=9.8.0
   version: 9.8.0
+  sha1: 71959d17235a1ce8c9ee58da136b7c04c74e3b31
 - name: postgres
   sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
@@ -2180,7 +2203,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-xenial
-  version: "621.109"
+  version: "621.125"
 update:
   canaries: 1
   canary_watch_time: 30000-1200000


### PR DESCRIPTION
Update to all spec result files for the inclusion of updated versions of all
packages.
Listed below:
- name: binary-buildpack
  version: 1.0.40
- name: bpm
  version: 1.1.14
- name: capi
  version: 1.119.0
- name: cf-networking
  version: 2.39.0
- name: cf-smoke-tests
  version: 41.0.2
- name: cflinuxfs3
  version: 0.262.0
- name: credhub
  version: 2.9.0
- name: diego
  version: 2.53.0
- name: dotnet-core-buildpack
  version: 2.3.34
- name: garden-runc
  version: 1.19.30
- name: go-buildpack
  version: 1.9.36
- name: java-buildpack
  version: "4.42"
- name: loggregator
  version: 106.6.0
- name: metrics-discovery
  version: 3.0.6
- name: nats
  version: "40"
- name: nginx-buildpack
  version: 1.1.32
- name: r-buildpack
  version: 1.1.22
- name: nodejs-buildpack
  version: 1.7.62
- name: php-buildpack
  version: 4.4.46
- name: pxc
  version: 0.39.0
- name: python-buildpack
  version: 1.7.46
- name: routing
  version: 0.225.0
- name: ruby-buildpack
  version: 1.8.47
- name: silk
 version: 2.39.0
- name: staticfile-buildpack
  version: 1.5.25
- name: statsd-injector
  version: 1.11.16
- name: uaa
  version: 75.8.0
- name: loggregator-agent
  version: 6.3.4
- name: log-cache
  version: 2.11.4
- name: bosh-dns-aliases
  version: 0.0.4
- name: cf-cli
  version: 1.34.0
- name: haproxy
  version: 9.8.0
- name: postgres
  version: "43"
Update to all spec credhub for the inclusion of
log_cache_nozzle_metrics_tls secrets
Support for bionic in CF kit