### PR TITLE
Windows 2019 diego cell support

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -64,6 +64,8 @@ General:
   - `no-nats-tls` - Nats over TLS was not part of cf-deployment v12.45, but has been turned on by default unless using bare mode.  Set this feature to disable it.
   - `ssh-proxy-on-routers` - moves the ssh-proxy from scheduler instance group to the router instance group, placing it on the edge network, and enabling scaling via scaling the routers.
   - `no-tcp-routers` - removes the tcp-router instance group and associated resource allocations for systems that don't need tcp routes.
+  - `windows-diego-cells` - Adds Windows Diego cell functionality.
+
 
 Database related - choose one:
   - `postgres-db` - Use an external postgres instance to host persistent data.
@@ -295,6 +297,12 @@ These params need to be set when activating features:
     | `locketdb_user` | Name of the Locket database user | `locketadmin` |
     | `credhubdb_name` | Name of the Credhub database | `credhubdb` |
     | `credhubdb_user` | Name of the Credhub database user | `credhubadmin` |
+
+  - **windows-diego-cells**:
+    | param | description | default |
+    | --- | --- | ---- |
+    | `windows_diego_cell_vm_type` | Windows Diego cell VM Type | `small-highmem` |
+    | `windows_diego_cell_instances`| Windows Diego Cell Instance Count | `1` |
 
 # Retired Parameters (from v1.x)
 

--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -225,6 +225,7 @@ for want in $GENESIS_REQUESTED_FEATURES; do
     minio-blobstore|aws-blobstore|aws-blobstore-iam|azure-blobstore|gcp-blobstore|gcp-use-access-key) features+=( "$want" ) ;;
     nfs-volume-services|enable-service-discovery|ssh-proxy-on-routers|no-tcp-routers) features+=( "$want" ) ;;
     app-autoscaler-integration|prometheus-integration|v2-nats-credentials) features+=( "$want" ) ;;
+    windows-diego-cells) features+=( "$want" ) ;;
     +migrated-v1-env|+override-db-names) features+=( "$want" ) ;;
     v1-vm-types|no-v1-vm-types)
       : # no-op, dealt with above
@@ -400,6 +401,23 @@ for want in $GENESIS_REQUESTED_FEATURES; do
       manifest+=( "overlay/addons/ssh-proxy-on-routers.yml" ) ;;
     no-tcp-routers)
       manifest+=( "overlay/addons/no-tcp-routers.yml" ) ;;
+    windows-diego-cells)
+      manifest+=( \
+        "cf-deployment/operations/windows2019-cell.yml" \
+        "cf-deployment/operations/use-online-windows2019fs.yml" \
+        "cf-deployment/operations/use-latest-windows2019-stemcell.yml" \
+      )
+      if want_feature "compiled-releases"; then
+        manifests+=( \
+          "cf-deployment/operations/experimental/use-compiled-releases-windows.yml" \
+        )
+      fi
+      if ! want_feature "bare" ; then
+        manifest+=( \
+          "overlay/windows.yml" \
+        )
+      fi
+      ) ;;
     +migrated-v1-env)
       manifest+=( "overlay/addons/migration.yml" ) ;;
 

--- a/overlay/windows.yml
+++ b/overlay/windows.yml
@@ -1,0 +1,20 @@
+instance_groups:
+- name: windows2019-cell
+  vm_type: (( grab params.windows_diego_cell_vm_type || "small-highmem" ))
+  networks: ((cf_runtime_network))
+  instances: (( grab params.windows_diego_cell_instances || "1"))
+  azs: (( grab meta.azs ))
+  jobs:
+  - name: resize_root_disk
+    release: windows-resize-root-disk
+    properties: {}
+  
+releases:
+- name: windows-resize-root-disk
+  version: 1.0
+  sha1: 8fe1adc3b6b6b68d8a370c576f649929f5452c6a
+  url: https://github.com/starkandwayne/windows-resize-root-disk/releases/download/v1.0/windows-resize-root-disk-release-1.0.tgz
+  
+  instances: (( grab params.windows_diego_cell_count || "1"))
+  azs: (( grab meta.azs ))
+  azs: (( grab meta.azs ))


### PR DESCRIPTION
Adds Windows 2019 Stemcell Support.
DONE:
- Adds basic support for Windows2019 Diego Cells
- SSH is enabled by default
- RDP is disabled by default
- Configurables:
  - `windows_diego_cell_vm_type`: vm type
  - `windows_diego_cell_instances`: instance count
 - Automatically resizes root disk to maximum available size (via [windows-resize-root-disk release](https://github.com/starkandwayne/windows-resize-root-disk)).
