### PR TITLE
Fixed result mismatch error in spec tests.

### DIFF
--- a/spec/results/compiled-windows-releases.yml
+++ b/spec/results/compiled-windows-releases.yml
@@ -2342,7 +2342,8 @@ instance_groups:
     release: cf-cli
   lifecycle: errand
   name: smb-broker-push
-  networks: cf-runtime
+  networks: 
+  - name: cf-runtime
   stemcell: default
   vm_type: minimal
 manifest_version: v16.25.0

--- a/spec/results/windows-and-smb-support.yml
+++ b/spec/results/windows-and-smb-support.yml
@@ -2342,7 +2342,8 @@ instance_groups:
     release: cf-cli
   lifecycle: errand
   name: smb-broker-push
-  networks: cf-runtime
+  networks: 
+  - name: cf-runtime
   stemcell: default
   vm_type: minimal
 manifest_version: v16.25.0


### PR DESCRIPTION
Tested this change by running `ginkgo watch` inside the concourse container of spectests. It made the tests pass successfully. 
`Ran 30 of 30 Specs in 384.924 seconds
SUCCESS! -- 30 Passed | 0 Failed | 0 Pending | 0 Skipped`