### PR TITLE
[TP-150] Fix failing acceptance test for dynamic ASG

### DIFF
--- a/ci/pipeline/resources/cats.yml
+++ b/ci/pipeline/resources/cats.yml
@@ -4,4 +4,4 @@ resources:
     check_every: 24h
     source:
       uri:         https://github.com/cloudfoundry/cf-acceptance-tests
-      tag_filter: "v*"
+      tag_filter: "v7.4.0"

--- a/ci/pipeline/resources/cats.yml
+++ b/ci/pipeline/resources/cats.yml
@@ -4,4 +4,4 @@ resources:
     check_every: 24h
     source:
       uri:         https://github.com/cloudfoundry/cf-acceptance-tests
-      tag_filter: "v7.4.0"
+      tag_filter: "v7.3.0"


### PR DESCRIPTION
Make the inputs resource for CATs refer not the latest but specific version.
Latest version of CATs (7.4.0, 7.5.0, 7.6.0) include a test for Dynamic ASG feature which is not covered by kit making test fail.
Reverting it to the 7.3.0 version of tests fixes it without removing other functionalities.

Full change log + code changes here:
https://github.com/cloudfoundry/cf-acceptance-tests/compare/v7.3.0...v7.6.0

PoW:
https://cloudpipes.starkandwayne.com/teams/genesis/pipelines/cf-genesis-kit/jobs/acceptance-tests/builds/11
