### PR TITLE
fixes blueprint typo on azure

### DIFF
--- a/hooks/blueprint
+++ b/hooks/blueprint
@@ -516,7 +516,7 @@ if ! want_feature "bare" ; then
     fi
     manifest+=( \
       "cf-deployment/operations/azure.yml"
-      "operations/azure-availability_sets.yml" \
+      "operations/azure_availability_sets.yml" \
     )
     ;;
   warden)


### PR DESCRIPTION
Blueprint typo causes spruce merge to reference /operations/azure-availability_sets.yml instead of the intended file /operations/azure_availability_sets.yml