### PR TITLE
Revert "update nfs version to support bionic"

### DIFF
--- a/cf-deployment/operations/enable-nfs-volume-service.yml
+++ b/cf-deployment/operations/enable-nfs-volume-service.yml
@@ -147,9 +147,9 @@
   path: /releases/-
   value:
     name: nfs-volume
-    sha1: "01b0f5a5c0b001a4d4e9a39c9577942e463d75a4"
-    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.6
-    version: 7.1.6
+    sha1: 6dbfcdb3ed5de63fd63e82710dfb58084c566f62
+    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.1
+    version: 7.1.1
 - type: replace
   path: /releases/name=mapfs?
   value:


### PR DESCRIPTION
Reverts genesis-community/cf-genesis-kit#204

This is being reverted because the following issues:

- You cannot change anything under the upstream-sourced `cf-deployment` directory.  You need to instead use release overrides: see https://github.com/genesis-community/cf-genesis-kit/tree/develop/overlay/override-releases/static.yml and https://github.com/genesis-community/cf-genesis-kit/blob/develop/hooks/blueprint#L126

- The spec tests were not updated and caused the pipeline to fail

- No release notes were included in the commit comments.  Please follow the following example:

  ```
  [<type>]

  * Description of change, and why
  ```

  where `<type>` is one of Improvements, Bug Fixes, Breaking Changes, or Kit Authoring Improvements