### PR TITLE
update nfs-volume-service for Bionic and Jammy stemcells, update mapfs to latest release

### DIFF
--- a/cf-deployment/operations/enable-nfs-volume-service.yml
+++ b/cf-deployment/operations/enable-nfs-volume-service.yml
@@ -147,13 +147,13 @@
   path: /releases/-
   value:
     name: nfs-volume
-    sha1: 6dbfcdb3ed5de63fd63e82710dfb58084c566f62
-    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.1
-    version: 7.1.1
+    sha1: 01b0f5a5c0b001a4d4e9a39c9577942e463d75a4
+    url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.6
+    version: 7.1.6
 - type: replace
   path: /releases/name=mapfs?
   value:
     name: mapfs
-    sha1: 440014423159187727d3622d41e5779f0f25902d
-    url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.2.6
-    version: 1.2.6
+    sha1: 15b4f8226e2032f6e1308f883ee5f133dd55e152
+    url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.2.11
+    version: 1.2.11

--- a/spec/results/isolation-segments-extended.yml
+++ b/spec/results/isolation-segments-extended.yml
@@ -2572,15 +2572,15 @@ releases:
   url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.34.0
   version: 1.34.0
 - name: nfs-volume
-  sha1: 6dbfcdb3ed5de63fd63e82710dfb58084c566f62
-  url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.1
-  version: 7.1.1
+  sha1: 01b0f5a5c0b001a4d4e9a39c9577942e463d75a4
+  url: https://bosh.io/d/github.com/cloudfoundry/nfs-volume-release?v=7.1.6
+  version: 7.1.6
 - name: mapfs
-  sha1: 440014423159187727d3622d41e5779f0f25902d
-  url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.2.6
-  version: 1.2.6
+  sha1: 15b4f8226e2032f6e1308f883ee5f133dd55e152
+  url: https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.2.11
+  version: 1.2.11
 - name: postgres
-  sha1: e44bbe8f8a7cdde1cda67b202e399a239d104db6
+  sha1: e44bbe8f68a7cdde1cda67b202e399a239d104db6
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=43
   version: "43"
 stemcells:


### PR DESCRIPTION

Updates:

* nfs-volume-release to 7.1.6 to add Bionic and Jammy support
* mapfs-release to 1.2.11