### PR TITLE
adding in fix for bosh-dns to iso segments

### DIFF
--- a/overlay/dynamic-templates/isolation-segment.yml
+++ b/overlay/dynamic-templates/isolation-segment.yml
@@ -99,6 +99,9 @@ instance_groups:
         graph_cleanup_threshold_in_mb: 0
         deny_networks:
         - 0.0.0.0/0
+        network_plugin: /var/vcap/packages/runc-cni/bin/garden-external-networker
+        network_plugin_extra_args:
+        - --configFile=/var/vcap/jobs/garden-cni/config/adapter.json
       logging:
         format:
           timestamp: "rfc3339"


### PR DESCRIPTION
Added in missing cni plug-in that was preventing iptables rules from auto creating allowing bosh-dns access