### PR TITLE
Update addon-scs

### DIFF
--- a/hooks/addon-scs
+++ b/hooks/addon-scs
@@ -203,7 +203,7 @@ then
           --arg "broker_name" "${broker_name}" \
           --arg "broker_old_name" "${broker_old_name}" \
           '.resources[].entity
-            | select(.name == $broker_name || .name == $broker_old_name)
+            | select(.name == $broker_name or .name == $broker_old_name)
             | .name'
   )
   broker_action="creat"


### PR DESCRIPTION
fixing jq issue for registering scs, `||` is not valid as an OR operator in a jq select, the word `or` is