### PR TITLE
Update trusted certs for cflinuxfs4

### DIFF
--- a/ocfp/trusted-certs.yml
+++ b/ocfp/trusted-certs.yml
@@ -13,4 +13,10 @@ instance_groups:
           trusted_certs:
             - (( append ))
             - (( join "" meta.ocfp.certs.trusted ))
+    - name: cflinuxfs4-rootfs-setup
+      properties:
+        cflinuxfs4-rootfs:
+          trusted_certs:
+            - (( append ))
+            - (( join "" meta.ocfp.certs.trusted ))
 


### PR DESCRIPTION
[Bugs]

* Addresses the absence of trusted certs on cflinufs4 for the ocfp reference infrastructure  @itsouvalas