### PR TITLE
scs addon stack

### DIFF
--- a/hooks/addon-scs
+++ b/hooks/addon-scs
@@ -46,6 +46,7 @@ scs_space_guid=$(cf space ${space} --guid)
 
 memory="256M"
 disk="1048M"
+stack="cflinuxfs4"
 buildpack="go_buildpack"
 release_tag="Greenwich.SR3"
 broker_uri="https://github.com/cloudfoundry-community/scs-broker/archive/refs/tags/v1.1.0.tar.gz"
@@ -77,6 +78,10 @@ do # Process opertor arguments
     (disk)
       disk="${2}"
       shift 2 || fail "Usage: ... disk <#M>"
+      ;;
+    (stack)
+      stack="${2}"
+      shift 2 || fail "Usage: ... stack <stack-name>"
       ;;
     (buildpack)
       buildpack="${2}"
@@ -136,6 +141,7 @@ then
 ---
 applications:
   - name: scs-broker
+    stack: ${stack}
     buildpack: ${buildpack}
     memory: ${memory}
     disk_quota: ${disk}


### PR DESCRIPTION
[Features]

* Adds the stack option to the addon-scs, allowing users to specify the desired stack when deploying the broker. @itsouvalas
* Defaults the stack to cflinuxfs4.
* Resolves an issue where the broker, previously deployed on cflinuxfs3, would continue to deploy on the same stack even though cflinuxfs4 is now the default stack in cf-deployment.