### PR TITLE
Export BBS client material for cf_exporter

### DIFF
--- a/overlay/addons/prometheus.yml
+++ b/overlay/addons/prometheus.yml
@@ -2,6 +2,9 @@
 exodus:
   firehose_exporter_secret: (( grab instance_groups.uaa.jobs.uaa.properties.uaa.clients.firehose_exporter.secret ))
   cf_exporter_secret:       (( grab instance_groups.uaa.jobs.uaa.properties.uaa.clients.cf_exporter.secret ))
+  bbs_ca:                   ((service_cf_internal_ca.certificate))
+  bbs_client_cert:          ((diego_bbs_client.certificate))
+  bbs_client_key:           ((diego_bbs_client.private_key))
 
 instance_groups:
 - name: uaa


### PR DESCRIPTION
The prometheus kit's cf_exporter moved to 2.x, which reads
running-instance counts from Diego BBS instead of the retired CF
v2 API. Connecting to BBS needs a client certificate that this
deployment already generates as diego_bbs_client.

This publishes the BBS client cert, key and signing CA to exodus,
alongside the existing cf_exporter and firehose secrets, so a
monitoring deployment can source them and authenticate to BBS.

Pairs with the prometheus-genesis-kit monitor-cf-bbs feature in
genesis-community/prometheus-genesis-kit#35.